### PR TITLE
Divide scale by active fleet size

### DIFF
--- a/pkg/controller/revision/revision_controller.go
+++ b/pkg/controller/revision/revision_controller.go
@@ -157,6 +157,7 @@ func (r *ReconcileRevision) SyncIncarnationsForRevision(revision *picchuv1alpha1
 				enabledClusters += 1
 			}
 		}
+		enabledClusters = max(enabledClusters, 1)
 		min := max(*target.Scale.Min/enabledClusters, 1)
 		scale := picchuv1alpha1.ScaleInfo{
 			Min:                            &min,


### PR DESCRIPTION
Hello @ddbenson, @dnelson, @silverlyra, @micahnoland, 

Please review the following commits I made in branch 'dokipen/20190321174607-divide-by-clusters':

- **Divide scale by active fleet size** (3890534280add1dc9d183eff8ceac8545d8b1e22)

- **Divide scale by enabled clusters** (3b848f681b95de44394ff3bbc25c9d81dda31cd5)

R=@ddbenson
R=@dnelson
R=@silverlyra
R=@micahnoland