### PR TITLE
Use proper client to delete remote namespace

### DIFF
--- a/pkg/controller/releasemanager/releasemanager_controller.go
+++ b/pkg/controller/releasemanager/releasemanager_controller.go
@@ -187,7 +187,7 @@ func (r *ResourceSyncer) DeleteNamespace() error {
 		},
 	}
 	// Might already be deleted
-	if err := r.PicchuClient.Delete(context.TODO(), namespace); err != nil && !errors.IsNotFound(err) {
+	if err := r.Client.Delete(context.TODO(), namespace); err != nil && !errors.IsNotFound(err) {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Hello @ddbenson, @dnelson, @silverlyra, @micahnoland, 

Please review the following commits I made in branch 'dokipen/20190322113011-rules':

- **Use proper client to delete remote namespace** (15894a1a55e90aef81faffd844d52bff80e2e31c)

R=@ddbenson
R=@dnelson
R=@silverlyra
R=@micahnoland