### PR TITLE
[MED-3557] Don't delete revisions if there are no clusters in target fleets

### DIFF
--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -396,7 +396,7 @@ func (i *Incarnation) syncHPA(ctx context.Context) error {
 
 // Remotely sync the incarnation for it's current state
 func (i *Incarnation) sync() error {
-	if i.revision == nil {
+	if i.revision == nil || i.target() == nil {
 		i.recordDeleted()
 		return i.del()
 	}

--- a/pkg/controller/revision/revision_controller.go
+++ b/pkg/controller/revision/revision_controller.go
@@ -204,8 +204,9 @@ func (r *ReconcileRevision) SyncReleaseManagersForRevision(revision *picchuv1alp
 		}
 	}
 
-	// if Revision is expired in all ReleaseManagers
-	if expiredCount == rmCount {
+	// if Revision is expired in all ReleaseManagers, without deleting
+	// clusterless revisions
+	if expiredCount == rmCount && expiredCount > 0 {
 		if err := r.DeleteRevision(revision); err != nil {
 			log.Error(err, "Failed to delete Revision")
 			return err


### PR DESCRIPTION
Hello @ddbenson, @dnelson, @silverlyra, @micahnoland, 

Please review the following commits I made in branch 'dokipen/20190411094952-revision-del':

- **Fixes corner-case where revision changes under releasemanager** (ac6d089ca4e8d11aca4c6fedb951f29f14dc9595)

- **Don't delete clusterless revisions** (161632ddb0b9f3ea7da1566b30ca89af9a39d585)

Related to [MED-3557](https://medium.atlassian.net/browse/MED-3557).

R=@ddbenson
R=@dnelson
R=@silverlyra
R=@micahnoland