### PR TITLE
[MED-3593] Fixes revision sorting in releasemanager

### DIFF
--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -570,10 +570,11 @@ func newIncarnationCollection(
 
 // Add adds a new Incarnation to the IncarnationManager
 func (i *IncarnationCollection) add(revision *picchuv1alpha1.Revision) {
+	r := *revision
 	i.itemSet[revision.Spec.App.Tag] = Incarnation{
 		tag:            revision.Spec.App.Tag,
 		releaseManager: i.releaseManager,
-		revision:       revision,
+		revision:       &r,
 		cluster:        i.cluster,
 		client:         i.client,
 		configFetcher:  i.configFetcher,
@@ -631,7 +632,7 @@ func (i *IncarnationCollection) deployed() []Incarnation {
 func (i *IncarnationCollection) sortedReleases() []Incarnation {
 	r := []Incarnation{}
 	for _, i := range i.sorted() {
-		if i.revision != nil && i.isDeployed() && i.isReleaseEligible() && !i.isRetired() {
+		if i.revision != nil && i.isDeployed() && i.isReleaseEligible() {
 			r = append(r, i)
 		}
 	}


### PR DESCRIPTION
Hello @ddbenson, @dnelson, @silverlyra, @micahnoland, 

Please review the following commits I made in branch 'dokipen/20190412111733-fix-sort':

- **Fixes revision sorting in releasemanager** (5f2c6a061ab15cd8f98f67ac63d16927f1e64c81)

Related to [MED-3593](https://medium.atlassian.net/browse/MED-3593).

R=@ddbenson
R=@dnelson
R=@silverlyra
R=@micahnoland