### PR TITLE
Add a Prometheus scrape label for apps with a status port

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.8
 
+RUN apk add --no-cache tzdata
+
 ENV OPERATOR=/usr/local/bin/picchu \
     USER_UID=1001 \
     USER_NAME=picchu

--- a/pkg/controller/releasemanager/releasemanager_controller.go
+++ b/pkg/controller/releasemanager/releasemanager_controller.go
@@ -31,6 +31,12 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
+const (
+	StatusPort                 = "status"
+	PrometheusScrapeLabel      = "prometheus.io/scrape"
+	PrometheusScrapeLabelValue = "true"
+)
+
 var (
 	log                       = logf.Log.WithName("controller_releasemanager")
 	incarnationReleaseLatency = promauto.NewHistogram(prometheus.HistogramOpts{
@@ -321,6 +327,9 @@ func (r *ResourceSyncer) syncService() error {
 		picchuv1alpha1.LabelApp:       r.instance.Spec.App,
 		picchuv1alpha1.LabelOwnerType: picchuv1alpha1.OwnerReleaseManager,
 		picchuv1alpha1.LabelOwnerName: r.instance.Name,
+	}
+	if _, hasStatus := portMap[StatusPort]; hasStatus {
+		labels[PrometheusScrapeLabel] = PrometheusScrapeLabelValue
 	}
 
 	service := &corev1.Service{


### PR DESCRIPTION
Hello @dokipen, @ddbenson, @dnelson, @micahnoland, 

Please review the following commits I made in branch 'silverlyra/scrape':

- **Add a Prometheus scrape label for apps with a status port** (b9638dc199d816ff90c607b357556ac36e8a8d47)

- **Add the tzdata package to the Docker image** (29e0f3a8e435931028825defa10218d1ca842db8)
  Fixes a bug introduced in #54.


R=@dokipen
R=@ddbenson
R=@dnelson
R=@micahnoland