### PR TITLE
[MED-3876] Add auditing and some FSM bug fixes

### DIFF
--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -725,7 +725,7 @@ func (i *IncarnationCollection) ensureValidRelease() {
 	r := []Incarnation{}
 	for _, i := range i.sorted() {
 		state := i.status.State.Current
-		if (state == "deployed" || state == "released") && i.status.ReleaseEligible {
+		if (state == "deployed" || state == "released") && i.isReleaseEligible() {
 			r = append(r, i)
 		}
 	}
@@ -776,7 +776,8 @@ func (i *IncarnationCollection) unretirable() []Incarnation {
 	for _, i := range i.sorted() {
 		cur := i.status.State.Current
 		elig := i.isReleaseEligible()
-		if cur == "retired" || (cur == "released" && !elig) {
+		triggered := i.isAlarmTriggered()
+		if cur == "retired" || (cur == "released" && !elig && !triggered) {
 			r = append(r, i)
 		}
 	}

--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -732,7 +732,7 @@ func (i *IncarnationCollection) ensureValidRelease() {
 
 	if len(r) == 0 {
 		i.controller.log().Info("there are no releases, looking for retired release to unretire")
-		candidates := i.retired()
+		candidates := i.unretirable()
 		if len(candidates) > 0 {
 			i.controller.log().Info("Unretiring", "tag", candidates[0].tag)
 			candidates[0].setReleaseEligible(true)
@@ -771,10 +771,12 @@ func (i *IncarnationCollection) releasable() []Incarnation {
 	return r
 }
 
-func (i *IncarnationCollection) retired() []Incarnation {
+func (i *IncarnationCollection) unretirable() []Incarnation {
 	r := []Incarnation{}
 	for _, i := range i.sorted() {
-		if i.status.State.Current == "retired" {
+		cur := i.status.State.Current
+		elig := i.isReleaseEligible()
+		if cur == "retired" || (cur == "released" && !elig) {
 			r = append(r, i)
 		}
 	}

--- a/pkg/controller/releasemanager/releasemanager_controller.go
+++ b/pkg/controller/releasemanager/releasemanager_controller.go
@@ -207,9 +207,6 @@ type ResourceSyncer struct {
 	log          logr.Logger
 }
 
-func (r *ResourceSyncer) isReleaseEligible(tag string) {
-}
-
 func (r *ResourceSyncer) getSecrets(ctx context.Context, opts *client.ListOptions) (*corev1.SecretList, error) {
 	secrets := &corev1.SecretList{}
 	err := r.client.List(ctx, opts, secrets)
@@ -594,6 +591,6 @@ func (r *ResourceSyncer) syncVirtualService() error {
 		return err
 	}
 
-	r.log.Info("VirtualService sync'd", "Op", op)
+	r.log.Info("VirtualService sync'd", "Type", "VirtualService", "Audit", true, "Content", vs, "Op", op)
 	return nil
 }

--- a/pkg/controller/releasemanager/releasemanager_controller.go
+++ b/pkg/controller/releasemanager/releasemanager_controller.go
@@ -507,7 +507,7 @@ func (r *ResourceSyncer) syncVirtualService() error {
 		incarnation.updateCurrentPercent(current)
 		r.log.Info("CurrentPercentage Update", "Tag", incarnation.tag, "Old", oldCurrent, "Current", current)
 		percRemaining -= current
-		if percRemaining <= 0 {
+		if percRemaining+current <= 0 {
 			incarnation.setReleaseEligible(false)
 		}
 

--- a/pkg/controller/releasemanager/releasemanager_controller.go
+++ b/pkg/controller/releasemanager/releasemanager_controller.go
@@ -431,7 +431,7 @@ func (r *ResourceSyncer) syncDestinationRule() error {
 		drule.Spec = spec
 		return nil
 	})
-	r.log.Info("DestinationRule sync'd", "Op", op)
+	r.log.Info("DestinationRule sync'd", "Type", "DestinationRule", "Audit", true, "Content", drule, "Op", op)
 	return err
 }
 

--- a/pkg/controller/releasemanager/releasemanager_controller.go
+++ b/pkg/controller/releasemanager/releasemanager_controller.go
@@ -266,6 +266,7 @@ func (r *ResourceSyncer) sync() (reconcile.Result, error) {
 		r.log.Error(err, "Failed to update releasemanager status")
 		return reconcile.Result{}, err
 	}
+	r.log.Info("Updated releasemanager status", "Content", r.instance.Status, "Type", "ReleaseManager.Status")
 	return reconcile.Result{RequeueAfter: r.reconciler.config.RequeueAfter}, nil
 }
 

--- a/pkg/controller/releasemanager/state.go
+++ b/pkg/controller/releasemanager/state.go
@@ -108,7 +108,7 @@ func (s *Deployed) tick(deployment Deployment) (State, error) {
 
 func (s *Deployed) reached(deployment Deployment) bool {
 	scale := deployment.getStatus().Scale
-	return scale.Current >= scale.Desired
+	return scale.Current >= scale.Desired && scale.Current >= 1
 }
 
 type Released struct{}
@@ -143,7 +143,7 @@ func (s *Retired) tick(deployment Deployment) (State, error) {
 }
 
 func (s *Retired) reached(deployment Deployment) bool {
-	return deployment.getStatus().Scale.Current == 0
+	return deployment.getStatus().Scale.Current+deployment.getStatus().Scale.Desired == 0
 }
 
 type Deleted struct{}

--- a/pkg/controller/revision/revision_controller.go
+++ b/pkg/controller/revision/revision_controller.go
@@ -192,6 +192,9 @@ func (r *ReconcileRevision) SyncReleaseManagersForRevision(revision *picchuv1alp
 
 			rmCount++
 			for _, rl := range rm.Status.Revisions {
+				if rl.GitTimestamp == nil {
+					continue
+				}
 				expiration := rl.GitTimestamp.Add(time.Duration(rl.TTL) * time.Second)
 				if rl.Tag == revision.Spec.App.Tag && rl.State.Current == "retired" && time.Now().After(expiration) {
 					retiredCount++


### PR DESCRIPTION
Hello @ddbenson, @dnelson, @silverlyra, @micahnoland, 

Please review the following commits I made in branch 'dokipen/20190425140246-bf':

- **Include releaseEligible==false state.current==released in unretirement calculus** (9beee4293eb69fe3f30daadb7ea07f6ba8548d25)

- **Fix retirement logic** (3872afaa0db25752b3ac1d325a65be885b350ca1)

- **Adds auditing to releasemanager.status** (a999ff6348b24164141a24e8281b0e4e7a8d2987)

- **Adds virtualService auditing to logs** (abc0cc8e80b124e15bae7afd6fe82b4c336a894d)

- **Small bug fixes** (6a6da379c7a3b541bb87ffb3875527882f6c88e4)

Related to [MED-3876](https://medium.atlassian.net/browse/MED-3876).

R=@ddbenson
R=@dnelson
R=@silverlyra
R=@micahnoland