### PR TITLE
Use revision creationTimestamp for scheduling

### DIFF
--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -171,7 +171,11 @@ func (i *Incarnation) retire() error {
 }
 
 func (i *Incarnation) schedulePermitsRelease() bool {
-	return schedulePermitsRelease(time.Now(), i.target().Release.Schedule)
+	if i.revision == nil {
+		return false
+	}
+	t := i.revision.GetCreationTimestamp().Time
+	return schedulePermitsRelease(t, i.target().Release.Schedule)
 }
 
 func (i *Incarnation) del() error {


### PR DESCRIPTION
Hello @ddbenson, @dnelson, @silverlyra, @micahnoland, 

Please review the following commits I made in branch 'dokipen/20190501092651-diverge':

- **Use revision creationTimestamp for scheduling** (fa4d911d612aad485a75e835a9cdba3d5d0d630d)


R=@ddbenson
R=@dnelson
R=@silverlyra
R=@micahnoland