### PR TITLE
Allow off-schedule revisions if we are in release schedule now

### DIFF
--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -174,8 +174,18 @@ func (i *Incarnation) schedulePermitsRelease() bool {
 	if i.revision == nil {
 		return false
 	}
-	t := i.revision.GetCreationTimestamp().Time
-	return schedulePermitsRelease(t, i.target().Release.Schedule)
+	// if the revision was created during release schedule or we are currently
+	// in the release schdeule
+	times := []time.Time{
+		i.revision.GetCreationTimestamp().Time,
+		time.Now(),
+	}
+	for _, t := range times {
+		if schedulePermitsRelease(t, i.target().Release.Schedule) {
+			return true
+		}
+	}
+	return false
 }
 
 func (i *Incarnation) del() error {

--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -171,7 +171,11 @@ func (i *Incarnation) retire() error {
 }
 
 func (i *Incarnation) schedulePermitsRelease() bool {
-	return schedulePermitsRelease(time.Now(), i.target().Release.Schedule)
+	if i.revision == nil {
+		return false
+	}
+	t := i.revision.GetCreationTimestamp().Time
+	return schedulePermitsRelease(t, i.target().Release.Schedule)
 }
 
 func (i *Incarnation) del() error {


### PR DESCRIPTION
Hello @ddbenson, @dnelson, @silverlyra, @micahnoland, 

Please review the following commits I made in branch 'dokipen/20190501092651-diverge':

- **Allow off-schedule revisions if we are in release schedule now** (878b85f97f9acb02fed58286bef04ccda9b4a62c)

- **Use revision creationTimestamp for scheduling** (fa4d911d612aad485a75e835a9cdba3d5d0d630d)


R=@ddbenson
R=@dnelson
R=@silverlyra
R=@micahnoland

:idea: still might be strange to release a bunch of deployments at the same time in the morning... but should work. We'll need some coordination to improve it.