### PR TITLE
Use releasemanager target instead of revision, which might be nil

### DIFF
--- a/pkg/controller/releasemanager/releasemanager_controller.go
+++ b/pkg/controller/releasemanager/releasemanager_controller.go
@@ -616,7 +616,7 @@ func (r *ResourceSyncer) syncVirtualService() error {
 				"app":            appName,
 				"tag":            incarnation.tag,
 				"target_cluster": r.cluster.Name,
-				"target":         incarnation.target().Name,
+				"target":         r.instance.Spec.Target,
 			}).
 			Set(float64(incarnation.status.CurrentPercent))
 	}


### PR DESCRIPTION
Hello @ddbenson, @dnelson, @silverlyra, @micahnoland, 

Please review the following commits I made in branch 'dokipen/20190506133956-nilp':

- **Use releasemanager target instead of revision, which might be nil** (63d05b8116aaa3c6b398b4cfc095cc07528949d6)


R=@ddbenson
R=@dnelson
R=@silverlyra
R=@micahnoland