### PR TITLE
Allow previously released deployments to release outside of schedule so rollbacks work

### DIFF
--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -179,6 +179,11 @@ func (i *Incarnation) schedulePermitsRelease() bool {
 		return false
 	}
 
+	// If previously released, allow outside of schedule
+	if i.status.PeakPercent > 0 {
+		return true
+	}
+
 	// if the revision was created during release schedule or we are currently
 	// in the release schdeule
 	times := []time.Time{


### PR DESCRIPTION
Hello @ddbenson, @dnelson, @silverlyra, @micahnoland, 

Please review the following commits I made in branch 'dokipen/20190506153416-unretire':

- **Allow previously released deployments to release outside of schedule so rollbacks work** (891a0f32c3fc081b00827d77e10e26902f52fb82)


R=@ddbenson
R=@dnelson
R=@silverlyra
R=@micahnoland