### PR TITLE
Don't create/update releasemanager for disabled clusters

### DIFF
--- a/pkg/controller/revision/revision_controller.go
+++ b/pkg/controller/revision/revision_controller.go
@@ -251,7 +251,7 @@ func (r *ReconcileRevision) SyncReleaseManagersForRevision(revision *picchuv1alp
 			return rstatus, err
 		}
 		for _, cluster := range clusters.Items {
-			if cluster.IsDeleted() {
+			if cluster.IsDeleted() || !cluster.Spec.Enabled {
 				continue
 			}
 			rm, err := r.GetOrCreateReleaseManager(&target, &cluster, revision)


### PR DESCRIPTION
Hello @ddbenson, @dnelson, @silverlyra, @micahnoland, 

Please review the following commits I made in branch 'dokipen/20190508151637-disabled-cluster':

- **Don't create/update releasemanager for disabled clusters** (5dff32a86be2e67933a02c3e1ee57a44efce118c)


R=@ddbenson
R=@dnelson
R=@silverlyra
R=@micahnoland