### PR TITLE
Measure picchu rollback time

### DIFF
--- a/pkg/apis/picchu/v1alpha1/common.go
+++ b/pkg/apis/picchu/v1alpha1/common.go
@@ -38,6 +38,7 @@ const (
 	AnnotationGitCommitterTimestamp     = "git-scm.com/committer-timestamp"
 	AnnotationRevisionCreationTimestamp = "revisionCreationTimestamp"
 	AnnotationIAMRole                   = "iam.amazonaws.com/role"
+	AnnotationFailedAt                  = "picchu.medium.engineering/failed-at-timestamp"
 )
 
 type PortInfo struct {

--- a/pkg/apis/picchu/v1alpha1/releasemanager_types.go
+++ b/pkg/apis/picchu/v1alpha1/releasemanager_types.go
@@ -60,9 +60,10 @@ type ReleaseManagerRevisionStatus struct {
 }
 
 type ReleaseManagerRevisionMetricsStatus struct {
-	GitReleaseSeconds     *float64 `json:"gitReleaseSeconds,omitempty"`
-	GitDeploySeconds      *float64 `json:"gitDeploySeconds,omitempty"`
-	RevisionDeploySeconds *float64 `json:"revisionDeploySeconds,omitempty"`
+	GitReleaseSeconds       *float64 `json:"gitReleaseSeconds,omitempty"`
+	GitDeploySeconds        *float64 `json:"gitDeploySeconds,omitempty"`
+	RevisionDeploySeconds   *float64 `json:"revisionDeploySeconds,omitempty"`
+	RevisionRollbackSeconds *float64 `json:"revisionRollbackSeconds,omitempty"`
 }
 
 type ReleaseManagerRevisionResourceStatus struct {

--- a/pkg/apis/picchu/v1alpha1/revision_test.go
+++ b/pkg/apis/picchu/v1alpha1/revision_test.go
@@ -1,0 +1,20 @@
+package v1alpha1
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFailRevision(t *testing.T) {
+	r := Revision{}
+	r.Fail()
+	failedAt, ok := r.Annotations[AnnotationFailedAt]
+	assert.True(t, ok, "FailedAt not set")
+	d := r.SinceFailed()
+	assert.NotEqual(t, d, time.Duration(0), "SinceFailed reports 0")
+	r.Fail()
+	failedAtNow := r.Annotations[AnnotationFailedAt]
+	assert.Equal(t, failedAt, failedAtNow, "FailedAt shouldn't update on subsequent calls")
+}

--- a/pkg/apis/picchu/v1alpha1/revision_types.go
+++ b/pkg/apis/picchu/v1alpha1/revision_types.go
@@ -28,6 +28,32 @@ type Revision struct {
 	Status RevisionStatus `json:"status,omitempty"`
 }
 
+func (r *Revision) Fail() {
+	if !r.Spec.Failed {
+		r.Spec.Failed = true
+		t := time.Now()
+		if r.Annotations == nil {
+			r.Annotations = map[string]string{
+				AnnotationFailedAt: t.Format(time.RFC3339),
+			}
+		} else {
+			r.Annotations[AnnotationFailedAt] = t.Format(time.RFC3339)
+		}
+	}
+}
+
+func (r *Revision) SinceFailed() time.Duration {
+	ft, ok := r.Annotations[AnnotationFailedAt]
+	if !ok {
+		return time.Duration(0)
+	}
+	t, err := time.Parse(time.RFC3339, ft)
+	if err != nil {
+		return time.Duration(0)
+	}
+	return time.Since(t)
+}
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // RevisionList contains a list of Revision

--- a/pkg/controller/revision/revision_controller.go
+++ b/pkg/controller/revision/revision_controller.go
@@ -131,7 +131,7 @@ func (r *ReconcileRevision) Reconcile(request reconcile.Request) (reconcile.Resu
 	}
 	if triggered && !status.IsRolloutComplete() && !instance.Spec.IgnoreSLOs {
 		op, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, instance, func(runtime.Object) error {
-			instance.Spec.Failed = true
+			instance.Fail()
 			return nil
 		})
 		if err != nil {


### PR DESCRIPTION
Hello @ddbenson, @dnelson, @silverlyra, @micahnoland, 

Please review the following commits I made in branch 'dokipen/20190520135124-rollback-metric':

- **Use revision.Fail() to fail revisions in revision controller** (3156bb763db50f99491f91f8df3f67b3a7853cd2)

- **Adds metric for rollback timing** (bb113a1a306981f8284ece792c2d0a182b93bee5)

- **Adds failed timestamp** (96d022b46a266a20df79211067024d0183e7273e)


R=@ddbenson
R=@dnelson
R=@silverlyra
R=@micahnoland