### PR TITLE
Preventing DestinationRule trafficPolicy from being overwritten

### DIFF
--- a/pkg/controller/releasemanager/releasemanager_controller.go
+++ b/pkg/controller/releasemanager/releasemanager_controller.go
@@ -453,7 +453,8 @@ func (r *ResourceSyncer) syncDestinationRule() error {
 	}
 
 	op, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, drule, func(runtime.Object) error {
-		drule.Spec = spec
+		drule.Spec.Host = spec.Host
+		drule.Spec.Subsets = spec.Subsets
 		return nil
 	})
 	r.log.Info("DestinationRule sync'd", "Type", "DestinationRule", "Audit", true, "Content", drule, "Op", op)


### PR DESCRIPTION
Hello @dokipen, @ddbenson, @dnelson, @silverlyra, 

Please review the following commits I made in branch 'micahnoland/destrule_sync':

- **Preventing DestinationRule trafficPolicy from being overwritten** (d811d66542055f816ec42381251cb9a99bb5b902)


R=@dokipen
R=@ddbenson
R=@dnelson
R=@silverlyra