### PR TITLE
Ensure revision statuses have non-null Git timestamps

### DIFF
--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -58,12 +58,15 @@ func NewIncarnation(controller Controller, tag string, revision *picchuv1alpha1.
 				}
 			}
 		} else {
-			status.GitTimestamp = &metav1.Time{}
 			status.ReleaseEligible = false
 		}
 		if status.State.Target == "" {
 			status.State.Target = "created"
 		}
+	}
+
+	if status.GitTimestamp == nil {
+		status.GitTimestamp = &metav1.Time{}
 	}
 
 	if status.RevisionTimestamp == nil {


### PR DESCRIPTION
Hello @dokipen, @ddbenson, @dnelson, @micahnoland, 

Please review the following commits I made in branch 'silverlyra/timestuck':

- **Ensure revision statuses have non-null Git timestamps** (4fd1e8b73dff85e702ad7295b60658eac33a950e)


R=@dokipen
R=@ddbenson
R=@dnelson
R=@micahnoland