### PR TITLE
Fix typo in livenessProbe, readinessProbe

### DIFF
--- a/pkg/apis/picchu/v1alpha1/revision_types.go
+++ b/pkg/apis/picchu/v1alpha1/revision_types.go
@@ -92,8 +92,8 @@ type RevisionTarget struct {
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
 	Resources      corev1.ResourceRequirements `json:"resources,omitempty"`
-	LivenessProbe  *corev1.Probe               `json:"livenessProve,omitempty"`
-	ReadinessProbe *corev1.Probe               `json:"readinessProve,omitempty"`
+	LivenessProbe  *corev1.Probe               `json:"livenessProbe,omitempty"`
+	ReadinessProbe *corev1.Probe               `json:"readinessProbe,omitempty"`
 }
 
 type RevisionTargetMetric struct {


### PR DESCRIPTION
Hello @dokipen, @micahnoland, 

Please review the following commits I made in branch 'silverlyra/prove':

- **Fix typo in livenessProbe, readinessProbe** (419bd35d96edb194ad3bbbbccf19721bb1499b02)
  :expressionless:

R=@dokipen
R=@micahnoland