### PR TITLE
Don't use DNS search on hosts with dots in them

### DIFF
--- a/pkg/controller/releasemanager/plan/syncRevision.go
+++ b/pkg/controller/releasemanager/plan/syncRevision.go
@@ -141,6 +141,7 @@ func (p *SyncRevision) Apply(ctx context.Context, cli client.Client, log logr.Lo
 		Spec: corev1.PodSpec{
 			ServiceAccountName: p.ServiceAccountName,
 			Containers:         []corev1.Container{appContainer},
+			DNSConfig:          DefaultDNSConfig(),
 		},
 	}
 
@@ -189,4 +190,14 @@ func (p *SyncRevision) Apply(ctx context.Context, cli client.Client, log logr.Lo
 		log.Info("Resource sync'd", "Audit", true, "Content", i, "Op", op)
 	}
 	return nil
+}
+
+func DefaultDNSConfig() *corev1.PodDNSConfig {
+	oneStr := "1"
+	return &corev1.PodDNSConfig{
+		Options: []corev1.PodDNSConfigOption{{
+			Name:  "ndots",
+			Value: &oneStr,
+		}},
+	}
 }

--- a/pkg/controller/releasemanager/plan/syncRevision_test.go
+++ b/pkg/controller/releasemanager/plan/syncRevision_test.go
@@ -51,9 +51,10 @@ var (
 		IAMRole:            "testrole",
 		ServiceAccountName: "testaccount",
 	}
-	one int32 = 1
+	one    int32 = 1
+	oneStr       = "1"
 
-	defaultExpected = &appsv1.ReplicaSet{
+	defaultExpectedReplicaSet = &appsv1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testtag",
 			Namespace: "testnamespace",
@@ -131,6 +132,12 @@ var (
 							FailureThreshold:    3,
 						},
 					}},
+					DNSConfig: &corev1.PodDNSConfig{
+						Options: []corev1.PodDNSConfigOption{{
+							Name:  "ndots",
+							Value: &oneStr,
+						}},
+					},
 				},
 			},
 		},
@@ -175,7 +182,7 @@ func TestSyncRevisionWithChange(t *testing.T) {
 
 	m.
 		EXPECT().
-		Update(ctx, k8sEqual(defaultExpected)).
+		Update(ctx, k8sEqual(defaultExpectedReplicaSet)).
 		Return(nil).
 		Times(1)
 
@@ -202,7 +209,7 @@ func TestSyncRevisionWithCreate(t *testing.T) {
 
 	m.
 		EXPECT().
-		Create(ctx, k8sEqual(defaultExpected)).
+		Create(ctx, k8sEqual(defaultExpectedReplicaSet)).
 		Return(nil).
 		Times(1)
 
@@ -234,7 +241,7 @@ func TestSyncRevisionWithCreateAndSecret(t *testing.T) {
 		},
 	}
 
-	expectedReplicaSet := defaultExpected.DeepCopy()
+	expectedReplicaSet := defaultExpectedReplicaSet.DeepCopy()
 	expectedReplicaSet.Spec.Template.Spec.Containers[0].EnvFrom = []corev1.EnvFromSource{{
 		ConfigMapRef: &corev1.ConfigMapEnvSource{
 			LocalObjectReference: corev1.LocalObjectReference{Name: "testconfigmap"},


### PR DESCRIPTION
Hello @ddbenson, @dnelson, @silverlyra, @micahnoland, 

Please review the following commits I made in branch 'dokipen/20190613093800-ndots':

- **Don't use DNS search on hosts with dots in them** (fe0ad1ac9aad1dfb6f50a1835bfa3e4b6979648a)


R=@ddbenson
R=@dnelson
R=@silverlyra
R=@micahnoland