### PR TITLE
Add new system pod labels feature

### DIFF
--- a/pkg/apis/picchu/v1alpha1/releasemanager_types.go
+++ b/pkg/apis/picchu/v1alpha1/releasemanager_types.go
@@ -56,6 +56,7 @@ type ReleaseManagerRevisionStatus struct {
 	Metrics           ReleaseManagerRevisionMetricsStatus `json:"metrics,omitempty"`
 	Scale             ReleaseManagerRevisionScaleStatus   `json:"scale"`
 	Deleted           bool                                `json:"deleted,omitempty"`
+	UseNewTagStyle    bool                                `json:"useNewTagStyle,omitempty"`
 }
 
 type ReleaseManagerRevisionMetricsStatus struct {

--- a/pkg/apis/picchu/v1alpha1/revision_types.go
+++ b/pkg/apis/picchu/v1alpha1/revision_types.go
@@ -70,6 +70,8 @@ type RevisionSpec struct {
 	Targets    []RevisionTarget `json:"targets"`
 	Failed     bool             `json:"failed"`
 	IgnoreSLOs bool             `json:"ignoreSLOs,omitempty"`
+	// This is immutable. Changing it has undefined behavior
+	UseNewTagStyle bool `json:"useNewTagStyle,omitempty"`
 }
 
 type RevisionApp struct {

--- a/pkg/apis/picchu/v1alpha1/revision_types.go
+++ b/pkg/apis/picchu/v1alpha1/revision_types.go
@@ -192,7 +192,7 @@ func (r *RevisionTargetStatus) AddReleaseManagerStatus(name string, status Relea
 }
 
 func (r *RevisionTargetStatus) IsRolloutComplete() bool {
-	return r.Release.PeakPercent >= 100
+	return r.Clusters.MaxPercent >= 100
 }
 
 func (r *Revision) GitTimestamp() time.Time {

--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -47,6 +47,7 @@ func NewIncarnation(controller Controller, tag string, revision *picchuv1alpha1.
 	status := controller.releaseManager().RevisionStatus(tag)
 	if status.State.Target == "" || status.State.Target == "created" || status.State.Target == "deployed" {
 		if revision != nil {
+			status.UseNewTagStyle = revision.Spec.UseNewTagStyle
 			status.GitTimestamp = &metav1.Time{revision.GitTimestamp()}
 			for _, target := range revision.Spec.Targets {
 				if target.Name == controller.releaseManager().Spec.Target {
@@ -133,6 +134,7 @@ func (i *Incarnation) sync() error {
 			Resources:          i.target().Resources,
 			IAMRole:            i.target().AWS.IAM.RoleARN,
 			ServiceAccountName: i.target().ServiceAccountName,
+			UseNewTagStyle:     i.status.UseNewTagStyle,
 		},
 		&plan.ScaleRevision{
 			Tag:       i.tag,

--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -380,11 +380,10 @@ func (i *Incarnation) syncPrometheusRules(ctx context.Context) error {
 			}}
 			return nil
 		})
+		plan.LogSync(i.log, op, err, rule)
 		if err != nil {
-			i.log.Info("Failed to sync'd PrometheusRule")
 			return err
 		}
-		i.log.Info("Sync'd PrometheusRule", "Op", op)
 	} else {
 		if err := i.controller.client().Delete(ctx, rule); err != nil && !errors.IsNotFound(err) {
 			i.log.Info("Failed to delete PrometheusRule")

--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -276,9 +276,12 @@ func (i *Incarnation) listOptions() (*client.ListOptions, error) {
 
 func (i *Incarnation) defaultLabels() map[string]string {
 	return map[string]string{
-		picchuv1alpha1.LabelApp:    i.appName(),
-		picchuv1alpha1.LabelTag:    i.tag,
-		picchuv1alpha1.LabelTarget: i.targetName(),
+		picchuv1alpha1.LabelApp:            i.appName(),
+		picchuv1alpha1.LabelTag:            i.tag,
+		picchuv1alpha1.LabelTarget:         i.targetName(),
+		"tag.picchu.medium.engineering":    i.tag,
+		"target.picchu.medium.engineering": i.targetName(),
+		"app.picchu.medium.engineering":    i.appName(),
 	}
 }
 

--- a/pkg/controller/releasemanager/plan/common.go
+++ b/pkg/controller/releasemanager/plan/common.go
@@ -1,0 +1,42 @@
+package plan
+
+import (
+	"go.medium.engineering/picchu/pkg/controller/utils"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func LogSync(log logr.Logger, op controllerutil.OperationResult, err error, resource runtime.Object) {
+	kind := utils.MustGetKind(resource).Kind
+	switch obj := resource.(type) {
+	case *autoscalingv1.HorizontalPodAutoscaler:
+		if err != nil {
+			log.Error(err, "Sync resource", "Result", "failure", "Kind", kind, "Audit", true, "Resource", obj.Spec, "Op", op)
+			return
+		}
+		log.Info("Sync resource", "Result", "success", "Kind", kind, "Audit", true, "Resource", obj.Spec, "Op", op)
+	case *corev1.Service:
+		if err != nil {
+			log.Error(err, "Sync resource", "Result", "failure", "Kind", kind, "Audit", true, "Resource", obj.Spec, "Op", op)
+			return
+		}
+		log.Info("Sync resource", "Result", "success", "Kind", kind, "Audit", true, "Resource", obj.Spec, "Op", op)
+	case *appsv1.ReplicaSet:
+		if err != nil {
+			log.Error(err, "Sync resource", "Result", "failure", "Kind", kind, "Audit", true, "Resource", obj.Spec, "Op", op)
+			return
+		}
+		log.Info("Sync resource", "Result", "success", "Kind", kind, "Audit", true, "Resource", obj.Spec, "Op", op)
+	default:
+		if err != nil {
+			log.Error(err, "Sync resource", "Result", "failure", "Kind", kind, "Audit", true, "Resource", resource, "Op", op)
+			return
+		}
+		log.Info("Sync resource", "Result", "success", "Kind", kind, "Audit", true, "Resource", resource, "Op", op)
+	}
+}

--- a/pkg/controller/releasemanager/plan/composite.go
+++ b/pkg/controller/releasemanager/plan/composite.go
@@ -20,6 +20,7 @@ func All(plans ...Plan) Plan {
 }
 
 func (p *compositePlan) Apply(ctx context.Context, cli client.Client, log logr.Logger) error {
+	log.Info("Applying Plan", "Plan", p)
 	for _, plan := range p.plans {
 		if err := plan.Apply(ctx, cli, log); err != nil {
 			return err

--- a/pkg/controller/releasemanager/plan/deleteApp.go
+++ b/pkg/controller/releasemanager/plan/deleteApp.go
@@ -15,6 +15,7 @@ type DeleteApp struct {
 }
 
 func (p *DeleteApp) Apply(ctx context.Context, cli client.Client, log logr.Logger) error {
+	log.Info("Applying Plan", "Plan", p)
 	item := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: p.Namespace,

--- a/pkg/controller/releasemanager/plan/deleteRevision.go
+++ b/pkg/controller/releasemanager/plan/deleteRevision.go
@@ -15,6 +15,7 @@ type DeleteRevision struct {
 }
 
 func (p *DeleteRevision) Apply(ctx context.Context, cli client.Client, log logr.Logger) error {
+	log.Info("Applying Plan", "Plan", p)
 	lists := []List{
 		NewSecretList(),
 		NewConfigMapList(),

--- a/pkg/controller/releasemanager/plan/ensureNamespace.go
+++ b/pkg/controller/releasemanager/plan/ensureNamespace.go
@@ -24,6 +24,7 @@ type EnsureNamespace struct {
 }
 
 func (p *EnsureNamespace) Apply(ctx context.Context, cli client.Client, log logr.Logger) error {
+	log.Info("Applying Plan", "Plan", p)
 	om := metav1.ObjectMeta{
 		Name: p.Name,
 		Labels: map[string]string{

--- a/pkg/controller/releasemanager/plan/ensureNamespace.go
+++ b/pkg/controller/releasemanager/plan/ensureNamespace.go
@@ -38,6 +38,6 @@ func (p *EnsureNamespace) Apply(ctx context.Context, cli client.Client, log logr
 		ns.ObjectMeta.Labels = om.Labels
 		return nil
 	})
-	log.Info("Namespace sync'd", "Op", op, "Content", ns, "Audit", "true", "Type", "Namespace")
+	LogSync(log, op, err, ns)
 	return err
 }

--- a/pkg/controller/releasemanager/plan/retireRevision.go
+++ b/pkg/controller/releasemanager/plan/retireRevision.go
@@ -16,6 +16,7 @@ type RetireRevision struct {
 }
 
 func (p *RetireRevision) Apply(ctx context.Context, cli client.Client, log logr.Logger) error {
+	log.Info("Applying Plan", "Plan", p)
 	rs := &appsv1.ReplicaSet{}
 	s := types.NamespacedName{p.Namespace, p.Tag}
 	err := cli.Get(ctx, s, rs)

--- a/pkg/controller/releasemanager/plan/scaleRevision.go
+++ b/pkg/controller/releasemanager/plan/scaleRevision.go
@@ -24,6 +24,9 @@ type ScaleRevision struct {
 
 func (p *ScaleRevision) Apply(ctx context.Context, cli client.Client, log logr.Logger) error {
 	log.Info("Applying plan", "Plan", p)
+	if p.Min > p.Max {
+		p.Max = p.Min
+	}
 	if p.CPUTarget != nil && *p.CPUTarget == 0 {
 		hpa := &autoscalingv1.HorizontalPodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/releasemanager/plan/scaleRevision.go
+++ b/pkg/controller/releasemanager/plan/scaleRevision.go
@@ -61,7 +61,8 @@ func (p *ScaleRevision) Apply(ctx context.Context, cli client.Client, log logr.L
 	}
 
 	op, err := controllerutil.CreateOrUpdate(ctx, cli, hpa, func(runtime.Object) error {
-		*hpa.Spec.MinReplicas = p.Min
+		min := p.Min
+		hpa.Spec.MinReplicas = &min
 		hpa.Spec.MaxReplicas = p.Max
 		return nil
 	})

--- a/pkg/controller/releasemanager/plan/scaleRevision.go
+++ b/pkg/controller/releasemanager/plan/scaleRevision.go
@@ -61,7 +61,7 @@ func (p *ScaleRevision) Apply(ctx context.Context, cli client.Client, log logr.L
 	}
 
 	op, err := controllerutil.CreateOrUpdate(ctx, cli, hpa, func(runtime.Object) error {
-		hpa.Spec.MinReplicas = &copyMin
+		*hpa.Spec.MinReplicas = p.Min
 		hpa.Spec.MaxReplicas = p.Max
 		return nil
 	})

--- a/pkg/controller/releasemanager/plan/scaleRevision.go
+++ b/pkg/controller/releasemanager/plan/scaleRevision.go
@@ -61,9 +61,6 @@ func (p *ScaleRevision) Apply(ctx context.Context, cli client.Client, log logr.L
 		hpa.Spec.MaxReplicas = p.Max
 		return nil
 	})
-	if err != nil {
-		return err
-	}
-	log.Info("HPA sync'd", "Type", "HPA", "Audit", true, "Content", hpa.Spec, "Op", op)
-	return nil
+	LogSync(log, op, err, hpa)
+	return err
 }

--- a/pkg/controller/releasemanager/plan/scaleRevision.go
+++ b/pkg/controller/releasemanager/plan/scaleRevision.go
@@ -23,6 +23,7 @@ type ScaleRevision struct {
 }
 
 func (p *ScaleRevision) Apply(ctx context.Context, cli client.Client, log logr.Logger) error {
+	log.Info("Applying plan", "Plan", p)
 	if p.CPUTarget != nil && *p.CPUTarget == 0 {
 		hpa := &autoscalingv1.HorizontalPodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/releasemanager/plan/syncRevision.go
+++ b/pkg/controller/releasemanager/plan/syncRevision.go
@@ -67,6 +67,7 @@ type SyncRevision struct {
 }
 
 func (p *SyncRevision) Apply(ctx context.Context, cli client.Client, log logr.Logger) error {
+	log.Info("Applying Plan", "Plan", p)
 	envs := []corev1.EnvFromSource{}
 
 	for _, i := range p.Configs {

--- a/pkg/controller/releasemanager/plan/syncRevision.go
+++ b/pkg/controller/releasemanager/plan/syncRevision.go
@@ -164,7 +164,6 @@ func (p *SyncRevision) Apply(ctx context.Context, cli client.Client, log logr.Lo
 	}
 
 	for _, i := range append(p.Configs, replicaSet) {
-		log.Info("Syncing resource", "item", i)
 		orig := i.DeepCopyObject()
 		op, err := controllerutil.CreateOrUpdate(ctx, cli, i, func(runtime.Object) error {
 			switch obj := i.(type) {
@@ -184,10 +183,10 @@ func (p *SyncRevision) Apply(ctx context.Context, cli client.Client, log logr.Lo
 			}
 			return nil
 		})
+		LogSync(log, op, err, i)
 		if err != nil {
 			return err
 		}
-		log.Info("Resource sync'd", "Audit", true, "Content", i, "Op", op)
 	}
 	return nil
 }

--- a/pkg/controller/releasemanager/plan/syncRevision.go
+++ b/pkg/controller/releasemanager/plan/syncRevision.go
@@ -64,6 +64,7 @@ type SyncRevision struct {
 	Resources          corev1.ResourceRequirements
 	IAMRole            string // AWS iam role
 	ServiceAccountName string // k8s ServiceAccount
+	UseNewTagStyle     bool
 }
 
 func (p *SyncRevision) Apply(ctx context.Context, cli client.Client, log logr.Logger) error {
@@ -130,6 +131,12 @@ func (p *SyncRevision) Apply(ctx context.Context, cli client.Client, log logr.Lo
 	podLabels := map[string]string{
 		picchuv1alpha1.LabelTag: p.Tag,
 		picchuv1alpha1.LabelApp: p.App,
+	}
+	if p.UseNewTagStyle {
+		podLabels = map[string]string{
+			"tag.picchu.medium.engineering": p.Tag,
+			"app.picchu.medium.engineering": p.App,
+		}
 	}
 
 	template := corev1.PodTemplateSpec{

--- a/pkg/controller/releasemanager/releasemanager_controller.go
+++ b/pkg/controller/releasemanager/releasemanager_controller.go
@@ -406,8 +406,7 @@ func (r *ResourceSyncer) syncService() error {
 		service.Spec.Selector = map[string]string{picchuv1alpha1.LabelApp: r.instance.Spec.App}
 		return nil
 	})
-
-	r.log.Info("Service sync'd", "Op", op)
+	plan.LogSync(r.log, op, err, service)
 	return err
 }
 
@@ -458,7 +457,7 @@ func (r *ResourceSyncer) syncDestinationRule() error {
 		drule.Spec.TrafficPolicy = spec.TrafficPolicy
 		return nil
 	})
-	r.log.Info("DestinationRule sync'd", "Type", "DestinationRule", "Audit", true, "Content", drule, "Op", op)
+	plan.LogSync(r.log, op, err, drule)
 	return err
 }
 
@@ -623,11 +622,11 @@ func (r *ResourceSyncer) syncVirtualService() error {
 		vs.Spec.Http = http
 		return nil
 	})
+	plan.LogSync(r.log, op, err, vs)
 	if err != nil {
 		return err
 	}
 
-	r.log.Info("VirtualService sync'd", "Type", "VirtualService", "Audit", true, "Content", vs, "Op", op)
 	for _, incarnation := range r.incarnations.sorted() {
 		revisionReleaseWeightGauge.
 			With(prometheus.Labels{

--- a/pkg/controller/releasemanager/releasemanager_controller.go
+++ b/pkg/controller/releasemanager/releasemanager_controller.go
@@ -213,7 +213,7 @@ func (r *ReconcileReleaseManager) countFleetCohort(namespace, fleet string) (uin
 	var cnt uint32 = 0
 	for _, cluster := range cl.Items {
 		for _, cond := range cluster.Status.Conditions {
-			if cond.Name == "Ready" && cond.Status == "True" {
+			if cond.Name == "Ready" && cond.Status == "True" && cluster.Spec.Enabled {
 				cnt++
 			}
 		}

--- a/pkg/controller/releasemanager/releasemanager_controller.go
+++ b/pkg/controller/releasemanager/releasemanager_controller.go
@@ -442,9 +442,13 @@ func (r *ResourceSyncer) syncDestinationRule() error {
 	subsets := []istiov1alpha3.Subset{}
 	for _, incarnation := range r.incarnations.deployed() {
 		tag := incarnation.tag
+		tagLabel := picchuv1alpha1.LabelTag
+		if incarnation.status.UseNewTagStyle {
+			tagLabel = "tag.picchu.medium.engineering"
+		}
 		subsets = append(subsets, istiov1alpha3.Subset{
 			Name:   tag,
-			Labels: map[string]string{picchuv1alpha1.LabelTag: tag},
+			Labels: map[string]string{tagLabel: tag},
 		})
 	}
 	spec := istiov1alpha3.DestinationRuleSpec{


### PR DESCRIPTION
Hello @ddbenson, @dnelson, @silverlyra, @micahnoland, 

Please review the following commits I made in branch 'dokipen/20190613111355-fix-bugs':

- **Add new system pod labels feature** (053a280d093bf531df9b45e9a65e6e3d3bd8de85)

- **Don't count disabled clusters against pool** (63015f5109588b259cff1eeac3065e589b442cd5)

- **Adds fields to releasemanager reconcile logger** (55d8c434eecbd28cd74e98840865b8789240767b)

- **Fix bug with min HPA setting** (1cddf513c262d0fa36c616bd87a6a3a07511b422)

- **Sanity for hpa min/max** (73a2b9adef42cab84be3d9e3afea8d541e6a21a6)

- **Adds plan logging** (576c82fcae0da74bf5a02eda9dbcbd942c046bea)

- **Adds common resource sync logging** (eeb8df77381be943b7554a216c257c98955c1d44)

- **Add new style labels to all resources** (0e387bed4b7dfcd762fb866e7a5fec057bbab0e7)

- **Consider revision released when at least one cluster hits 100%** (85ebe2e192a8521eedcebe2a8d07e822b68804a6)


R=@ddbenson
R=@dnelson
R=@silverlyra
R=@micahnoland