### PR TITLE
Allow tagged routing header by revision

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -52,7 +52,6 @@ func main() {
 
 	manageRoute53 := pflag.Bool("manage-route53", false, "Should picchu manage route53?")
 	requeuePeriodSeconds := pflag.Int("sync-period-seconds", 15, "Delay between requeues")
-	taggedRoutesEnabled := pflag.Bool("tagged-routes", false, "Enable tagged routes in istio")
 	prometheusQueryAddress := pflag.String("prometheus-query-address", "", "The (usually thanos) address that picchu should query to SLO alerts")
 	prometheusQueryTTL := pflag.Duration("prometheus-query-ttl", time.Duration(10)*time.Second, "How long to cache SLO alerts")
 
@@ -129,7 +128,6 @@ func main() {
 	config := utils.Config{
 		ManageRoute53:          *manageRoute53,
 		RequeueAfter:           requeuePeriod,
-		TaggedRoutesEnabled:    *taggedRoutesEnabled,
 		PrometheusQueryAddress: *prometheusQueryAddress,
 		PrometheusQueryTTL:     *prometheusQueryTTL,
 	}

--- a/pkg/apis/picchu/v1alpha1/revision_types.go
+++ b/pkg/apis/picchu/v1alpha1/revision_types.go
@@ -66,14 +66,13 @@ type RevisionList struct {
 
 // RevisionSpec defines the desired state of Revision
 type RevisionSpec struct {
-	App           RevisionApp                  `json:"app"`
-	Ports         []PortInfo                   `json:"ports"`
-	Targets       []RevisionTarget             `json:"targets"`
-	TrafficPolicy *istiov1alpha3.TrafficPolicy `json:"trafficPolicy,omitempty"`
-	Failed        bool                         `json:"failed"`
-	IgnoreSLOs    bool                         `json:"ignoreSLOs,omitempty"`
-	// This is immutable. Changing it has undefined behavior
-	UseNewTagStyle bool `json:"useNewTagStyle,omitempty"`
+	App              RevisionApp                  `json:"app"`
+	Ports            []PortInfo                   `json:"ports"`
+	Targets          []RevisionTarget             `json:"targets"`
+	TrafficPolicy    *istiov1alpha3.TrafficPolicy `json:"trafficPolicy,omitempty"`
+	Failed           bool                         `json:"failed"`
+	IgnoreSLOs       bool                         `json:"ignoreSLOs,omitempty"`
+	TagRoutingHeader string                       `json:"tagRoutingHeader,omitempty"`
 }
 
 type RevisionApp struct {

--- a/pkg/controller/releasemanager/plan/syncApp_test.go
+++ b/pkg/controller/releasemanager/plan/syncApp_test.go
@@ -32,8 +32,9 @@ var (
 		PublicGateway:  "public-gateway",
 		PrivateGateway: "private-gateway",
 		DeployedRevisions: []Revision{{
-			Tag:    "testtag",
-			Weight: 100,
+			Tag:              "testtag",
+			Weight:           100,
+			TagRoutingHeader: "MEDIUM-TAG",
 		}},
 		AlertRules: []monitoringv1.Rule{{
 			Expr: intstr.FromString("hello world"),
@@ -53,7 +54,6 @@ var (
 			Protocol:      corev1.ProtocolTCP,
 			Mode:          picchuv1alpha1.PortLocal,
 		}},
-		TagRoutingHeader: "MEDIUM-TAG",
 		TrafficPolicy: &istiov1alpha3.TrafficPolicy{
 			ConnectionPool: &istiov1alpha3.ConnectionPoolSettings{
 				Http: &istiov1alpha3.HTTPSettings{

--- a/pkg/controller/releasemanager/syncer.go
+++ b/pkg/controller/releasemanager/syncer.go
@@ -20,15 +20,14 @@ import (
 )
 
 type ResourceSyncer struct {
-	deliveryClient   client.Client
-	planApplier      plan.Applier
-	observer         observe.Observer
-	instance         *picchuv1alpha1.ReleaseManager
-	incarnations     *IncarnationCollection
-	reconciler       *ReconcileReleaseManager
-	log              logr.Logger
-	clusterConfig    ClusterConfig
-	tagRoutingHeader string
+	deliveryClient client.Client
+	planApplier    plan.Applier
+	observer       observe.Observer
+	instance       *picchuv1alpha1.ReleaseManager
+	incarnations   *IncarnationCollection
+	reconciler     *ReconcileReleaseManager
+	log            logr.Logger
+	clusterConfig  ClusterConfig
 }
 
 func (r *ResourceSyncer) getSecrets(ctx context.Context, opts *client.ListOptions) ([]runtime.Object, error) {
@@ -179,7 +178,6 @@ func (r *ResourceSyncer) syncApp(ctx context.Context) error {
 		DeployedRevisions: revisions,
 		AlertRules:        alertRules,
 		Ports:             ports,
-		TagRoutingHeader:  r.tagRoutingHeader,
 		TrafficPolicy:     r.currentTrafficPolicy(),
 	})
 	if err != nil {
@@ -223,9 +221,14 @@ func (r *ResourceSyncer) prepareRevisionsAndRules() ([]plan.Revision, []monitori
 
 	revisionsMap := map[string]plan.Revision{}
 	for _, i := range r.incarnations.deployed() {
+		tagRoutingHeader := ""
+		if i.revision != nil {
+			tagRoutingHeader = i.revision.Spec.TagRoutingHeader
+		}
 		revisionsMap[i.tag] = plan.Revision{
-			Tag:    i.tag,
-			Weight: 0,
+			Tag:              i.tag,
+			Weight:           0,
+			TagRoutingHeader: tagRoutingHeader,
 		}
 	}
 

--- a/pkg/controller/releasemanager/syncer.go
+++ b/pkg/controller/releasemanager/syncer.go
@@ -262,9 +262,14 @@ func (r *ResourceSyncer) prepareRevisionsAndRules() ([]plan.Revision, []monitori
 		if percRemaining+current <= 0 {
 			incarnation.setReleaseEligible(false)
 		}
+		tagRoutingHeader := ""
+		if incarnation.revision != nil {
+			tagRoutingHeader = incarnation.revision.Spec.TagRoutingHeader
+		}
 		revisionsMap[incarnation.tag] = plan.Revision{
-			Tag:    incarnation.tag,
-			Weight: current,
+			Tag:              incarnation.tag,
+			Weight:           current,
+			TagRoutingHeader: tagRoutingHeader,
 		}
 	}
 

--- a/pkg/controller/utils/config.go
+++ b/pkg/controller/utils/config.go
@@ -5,7 +5,6 @@ import "time"
 type Config struct {
 	ManageRoute53          bool
 	RequeueAfter           time.Duration
-	TaggedRoutesEnabled    bool
 	PrometheusQueryAddress string
 	PrometheusQueryTTL     time.Duration
 }


### PR DESCRIPTION
Hello @matkam, @eblume, @ddbenson, @dnelson, @silverlyra, @micahnoland, 

Please review the following commits I made in branch 'dokipen/20190726131333-tag-headers':

- **Allow tagged routing header by revision** (00b452f29c7ab704f9c1e50dfcc94803026dd8b6)


R=@matkam
R=@eblume
R=@ddbenson
R=@dnelson
R=@silverlyra
R=@micahnoland


:bulb: Not deploying this until we have a new test cluster (maybe old delivery+gold when kbfd is moved)