### PR TITLE
Adding SLI CanaryType

### DIFF
--- a/pkg/apis/picchu/v1alpha1/revision_types.go
+++ b/pkg/apis/picchu/v1alpha1/revision_types.go
@@ -72,6 +72,7 @@ type RevisionSpec struct {
 	TrafficPolicy    *istiov1alpha3.TrafficPolicy `json:"trafficPolicy,omitempty"`
 	Failed           bool                         `json:"failed"`
 	IgnoreSLOs       bool                         `json:"ignoreSLOs,omitempty"`
+	CanaryType       CanaryType                   `json:"canaryType,omitempty"`
 	Sentry           SentryInfo                   `json:"sentry"`
 	TagRoutingHeader string                       `json:"tagRoutingHeader,omitempty"`
 }
@@ -113,6 +114,13 @@ type Canary struct {
 	Percent uint32 `json:"percent"`
 	TTL     int64  `json:"ttl"`
 }
+
+type CanaryType string
+
+const (
+	SLO CanaryType = "slo"
+	SLI CanaryType = "sli"
+)
 
 type RevisionTargetMetric struct {
 	Name      string                      `json:"name"`

--- a/pkg/apis/picchu/v1alpha1/source_defaults.go
+++ b/pkg/apis/picchu/v1alpha1/source_defaults.go
@@ -18,6 +18,7 @@ const (
 	defaultPortPort          = int32(80)
 	defaultPortProtocol      = corev1.ProtocolTCP
 	defaultPortMode          = PortPrivate
+	defaultCanaryType        = SLO
 )
 
 func SetDefaults_RevisionSpec(spec *RevisionSpec) {
@@ -27,6 +28,9 @@ func SetDefaults_RevisionSpec(spec *RevisionSpec) {
 	}
 	for i, _ := range spec.Ports {
 		SetPortDefaults(&spec.Ports[i])
+	}
+	if spec.CanaryType == "" {
+		spec.CanaryType = defaultCanaryType
 	}
 }
 

--- a/pkg/controller/revision/revision_controller.go
+++ b/pkg/controller/revision/revision_controller.go
@@ -168,7 +168,7 @@ func (r *ReconcileRevision) Reconcile(request reconcile.Request) (reconcile.Resu
 		}
 	}
 
-	triggered, err := r.promAPI.IsRevisionTriggered(context.TODO(), instance.Spec.App.Name, instance.Spec.App.Tag)
+	triggered, err := r.promAPI.IsRevisionTriggered(context.TODO(), instance.Spec.App.Name, instance.Spec.App.Tag, string(instance.Spec.CanaryType))
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/prometheus/api.go
+++ b/pkg/prometheus/api.go
@@ -16,7 +16,7 @@ import (
 var (
 	alertTemplate = template.Must(template.
 			New("taggedAlerts").
-			Parse(`sum by({{.TagLabel}},app)(ALERTS{slo="true",alertstate="{{.AlertState}}"})`))
+			Parse(`sum by({{.TagLabel}},app)(ALERTS{ {{.AlertType}}="true",alertstate="{{.AlertState}}"})`))
 	log = logf.Log.WithName("prometheus_alerts")
 )
 
@@ -28,13 +28,15 @@ type AlertQuery struct {
 	App        string
 	AlertState string
 	TagLabel   string
+	AlertType  string
 }
 
-func NewAlertQuery(app string) AlertQuery {
+func NewAlertQuery(app, alertType string) AlertQuery {
 	return AlertQuery{
 		App:        app,
 		AlertState: "firing",
 		TagLabel:   "tag",
+		AlertType:  alertType,
 	}
 }
 
@@ -131,8 +133,8 @@ func (a API) TaggedAlerts(ctx context.Context, query AlertQuery, t time.Time) ([
 
 // IsRevisionTriggered returns true if any slo alerts are currently triggered
 // for the app/tag pair.
-func (a API) IsRevisionTriggered(ctx context.Context, app, tag string) (bool, error) {
-	q := NewAlertQuery(app)
+func (a API) IsRevisionTriggered(ctx context.Context, app, tag, alertType string) (bool, error) {
+	q := NewAlertQuery(app, alertType)
 	tags, err := a.TaggedAlerts(ctx, q, time.Now())
 	if err != nil {
 		return false, err

--- a/pkg/prometheus/api_test.go
+++ b/pkg/prometheus/api_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
+	picchuv1alpha1 "go.medium.engineering/picchu/pkg/apis/picchu/v1alpha1"
 	"go.medium.engineering/picchu/pkg/prometheus/mocks"
 )
 
@@ -20,7 +21,7 @@ func TestPrometheusCache(t *testing.T) {
 	m := mocks.NewMockPromAPI(ctrl)
 	api := InjectAPI(m, time.Duration(25)*time.Millisecond)
 
-	aq := NewAlertQuery("tutu")
+	aq := NewAlertQuery("tutu", string(picchuv1alpha1.SLO))
 
 	q := bytes.NewBufferString("")
 	assert.Nil(t, alertTemplate.Execute(q, aq), "Template execute shouldn't fail")
@@ -50,7 +51,7 @@ func TestPrometheusAlerts(t *testing.T) {
 	m := mocks.NewMockPromAPI(ctrl)
 	api := InjectAPI(m, time.Duration(25)*time.Millisecond)
 
-	aq := NewAlertQuery("tutu")
+	aq := NewAlertQuery("tutu", string(picchuv1alpha1.SLO))
 
 	q := bytes.NewBufferString("")
 	assert.Nil(t, alertTemplate.Execute(q, aq), "Template execute shouldn't fail")


### PR DESCRIPTION
The idea behind this implementation is to use the existing framework for Prometheus rule definition for SLI (Service Level Indicator) that we use for SLO (Service Level Objective). 

1. Create recording rule for availability by workload
2. Create recording rule for availability by service
3. Compare workload with service with a fudge factor, like 5% (0.05)

```
    alertRules:
    - alert: ServiceAvailabilitySLO
      expr: >-
        test:availability_workload:rate2m < 0.99
      for: 5m
      annotations:
        message: >-
          service has low overall availability
      labels:
        severity: critical
        app: test
        slo: 'true'
    - alert: ServiceAvailabilitySLI
      expr: >-
        test:availability_workload:rate2m < test:availability_service:rate10m + 0.05
      for: 5m
      annotations:
        message: >-
          service has low overall availability   
      labels:
        severity: critical
        app: test
        sli: 'true'
    - record: test:availability_workload:rate2m
      expr: >-
        sum(rate(istio_requests_total{reporter="source", destination_service="test.test.svc.cluster.local", response_code=~"[234][0-9]{2}"}[2m])) by (destination_workload)
        / sum(rate(istio_requests_total{reporter="source", destination_service="test.test.svc.cluster.local"}[2m])) by (destination_workload)
    - record: test:availability_service:rate10m
      expr: >-
        sum(rate(istio_requests_total{reporter="source", destination_service="test.test.svc.cluster.local", response_code=~"[234][0-9]{2}"}[10m])) by (destination_service)
        / sum(rate(istio_requests_total{reporter="source", destination_service="test.test.svc.cluster.local"}[10m])) by (destination_service)
```