### PR TITLE
Fixing off-hours scheduling when canaries are enabled

### DIFF
--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -226,7 +226,7 @@ func (i *Incarnation) schedulePermitsRelease() bool {
 	}
 
 	// If previously released, allow outside of schedule
-	if i.status.PeakPercent > 0 {
+	if i.status.PeakPercent > 0 && i.status.PeakPercent > i.target().Canary.Percent {
 		return true
 	}
 


### PR DESCRIPTION
Hello @dokipen, @ddbenson, @dnelson, @eblume, @silverlyra, @matkam, @tonymeng, 

Please review the following commits I made in branch 'micahnoland/canary_schedule_fix':

- **Fixing off-hours scheduling when canaries are enabled** (1877d58adc06a92052389a84beb6a346548ed6eb)


R=@dokipen
R=@ddbenson
R=@dnelson
R=@eblume
R=@silverlyra
R=@matkam
R=@tonymeng