### PR TITLE
Revert "Move ports to target configuration in revision (#123)"

### DIFF
--- a/deploy/crds/picchu_v1alpha1_revision.yaml
+++ b/deploy/crds/picchu_v1alpha1_revision.yaml
@@ -104,33 +104,6 @@ spec:
             targets:
               items:
                 properties:
-                  ports:
-                    items:
-                      properties:
-                        containerPort:
-                          format: int32
-                          type: integer
-                        hosts:
-                          items:
-                            type: string
-                          type: array
-                        ingressPort:
-                          format: int32
-                          type: integer
-                        mode:
-                          type: string
-                        name:
-                          type: string
-                        port:
-                          format: int32
-                          type: integer
-                        protocol:
-                          type: string
-                      required:
-                      - name
-                      - mode
-                      type: object
-                    type: array
                   aws:
                     properties:
                       iam:

--- a/pkg/apis/picchu/v1alpha1/revision_types.go
+++ b/pkg/apis/picchu/v1alpha1/revision_types.go
@@ -101,7 +101,6 @@ type RevisionTarget struct {
 
 	ExternalTest ExternalTest `json:"externalTest"`
 	Canary       Canary       `json:"canary"`
-	Ports        []PortInfo   `json:"ports"`
 }
 
 type ExternalTest struct {

--- a/pkg/apis/picchu/v1alpha1/source_defaults.go
+++ b/pkg/apis/picchu/v1alpha1/source_defaults.go
@@ -28,11 +28,6 @@ func SetDefaults_RevisionSpec(spec *RevisionSpec) {
 	for i, _ := range spec.Ports {
 		SetPortDefaults(&spec.Ports[i])
 	}
-	for i, _ := range spec.Targets {
-		for j, _ := range spec.Targets[i].Ports {
-			SetPortDefaults(&spec.Targets[i].Ports[j])
-		}
-	}
 }
 
 func SetReleaseDefaults(release *ReleaseInfo) {

--- a/pkg/apis/picchu/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/picchu/v1alpha1/zz_generated.deepcopy.go
@@ -1109,13 +1109,6 @@ func (in *RevisionTarget) DeepCopyInto(out *RevisionTarget) {
 	}
 	out.ExternalTest = in.ExternalTest
 	out.Canary = in.Canary
-	if in.Ports != nil {
-		in, out := &in.Ports, &out.Ports
-		*out = make([]PortInfo, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
-	}
 	return
 }
 

--- a/pkg/controller/releasemanager/syncer.go
+++ b/pkg/controller/releasemanager/syncer.go
@@ -156,7 +156,7 @@ func (r *ResourceSyncer) syncApp(ctx context.Context) error {
 	}
 
 	for _, incarnation := range incarnations {
-		for _, port := range incarnation.ports() {
+		for _, port := range incarnation.revision.Spec.Ports {
 			_, ok := portMap[port.Name]
 			if !ok {
 				portMap[port.Name] = port


### PR DESCRIPTION
Hello @dokipen, @ddbenson, @dnelson, @eblume, @matkam, @micahnoland, @tonymeng, 

Please review the following commits I made in branch 'silverlyra/revert-pr-123':

- **Revert "Move ports to target configuration in revision (#123)"** (89bb6581335698293568e2d84f2581452f45af13)
This reverts commit d3d175fbaa73c7e85af33f15df8eb73709db10e6.


R=@dokipen
R=@ddbenson
R=@dnelson
R=@eblume
R=@matkam
R=@micahnoland
R=@tonymeng

:point_right: The OpenAPI validation changes for this are causing problems.