### PR TITLE
Reroll ports in targets

### DIFF
--- a/deploy/crds/picchu_v1alpha1_revision.yaml
+++ b/deploy/crds/picchu_v1alpha1_revision.yaml
@@ -237,7 +237,6 @@ spec:
               type: array
           required:
           - app
-          - ports
           - targets
           type: object
         status:

--- a/deploy/crds/picchu_v1alpha1_revision.yaml
+++ b/deploy/crds/picchu_v1alpha1_revision.yaml
@@ -104,6 +104,33 @@ spec:
             targets:
               items:
                 properties:
+                  ports:
+                    items:
+                      properties:
+                        containerPort:
+                          format: int32
+                          type: integer
+                        hosts:
+                          items:
+                            type: string
+                          type: array
+                        ingressPort:
+                          format: int32
+                          type: integer
+                        mode:
+                          type: string
+                        name:
+                          type: string
+                        port:
+                          format: int32
+                          type: integer
+                        protocol:
+                          type: string
+                      required:
+                      - name
+                      - mode
+                      type: object
+                    type: array
                   aws:
                     properties:
                       iam:

--- a/pkg/apis/picchu/v1alpha1/revision_types.go
+++ b/pkg/apis/picchu/v1alpha1/revision_types.go
@@ -101,6 +101,7 @@ type RevisionTarget struct {
 
 	ExternalTest ExternalTest `json:"externalTest"`
 	Canary       Canary       `json:"canary"`
+	Ports        []PortInfo   `json:"ports"`
 }
 
 type ExternalTest struct {

--- a/pkg/apis/picchu/v1alpha1/revision_types.go
+++ b/pkg/apis/picchu/v1alpha1/revision_types.go
@@ -101,7 +101,7 @@ type RevisionTarget struct {
 
 	ExternalTest ExternalTest `json:"externalTest"`
 	Canary       Canary       `json:"canary"`
-	Ports        []PortInfo   `json:"ports"`
+	Ports        []PortInfo   `json:"ports,omitempty"`
 }
 
 type ExternalTest struct {

--- a/pkg/apis/picchu/v1alpha1/revision_types.go
+++ b/pkg/apis/picchu/v1alpha1/revision_types.go
@@ -67,7 +67,7 @@ type RevisionList struct {
 // RevisionSpec defines the desired state of Revision
 type RevisionSpec struct {
 	App              RevisionApp                  `json:"app"`
-	Ports            []PortInfo                   `json:"ports"`
+	Ports            []PortInfo                   `json:"ports,omitempty"`
 	Targets          []RevisionTarget             `json:"targets"`
 	TrafficPolicy    *istiov1alpha3.TrafficPolicy `json:"trafficPolicy,omitempty"`
 	Failed           bool                         `json:"failed"`

--- a/pkg/apis/picchu/v1alpha1/source_defaults.go
+++ b/pkg/apis/picchu/v1alpha1/source_defaults.go
@@ -28,6 +28,11 @@ func SetDefaults_RevisionSpec(spec *RevisionSpec) {
 	for i, _ := range spec.Ports {
 		SetPortDefaults(&spec.Ports[i])
 	}
+	for i, _ := range spec.Targets {
+		for j, _ := range spec.Targets[i].Ports {
+			SetPortDefaults(&spec.Targets[i].Ports[j])
+		}
+	}
 }
 
 func SetReleaseDefaults(release *ReleaseInfo) {

--- a/pkg/apis/picchu/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/picchu/v1alpha1/zz_generated.deepcopy.go
@@ -1109,6 +1109,13 @@ func (in *RevisionTarget) DeepCopyInto(out *RevisionTarget) {
 	}
 	out.ExternalTest = in.ExternalTest
 	out.Canary = in.Canary
+	if in.Ports != nil {
+		in, out := &in.Ports, &out.Ports
+		*out = make([]PortInfo, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -111,6 +111,21 @@ func (i *Incarnation) isCanaryPending() bool {
 	return target.IsCanaryPending(i.status.CanaryStartTimestamp)
 }
 
+func (i *Incarnation) ports() []picchuv1alpha1.PortInfo {
+	ports := i.revision.Spec.Ports
+	target := i.target()
+
+	if target != nil {
+		if len(target.Ports) > 0 {
+			ports = target.Ports
+		} else {
+			i.log.Info("revision.spec.ports is deprecated", "tag", i.tag)
+		}
+	}
+
+	return ports
+}
+
 func (i *Incarnation) currentPercent() uint32 {
 	if i.getStatus() == nil {
 		return 0
@@ -178,7 +193,7 @@ func (i *Incarnation) sync(ctx context.Context) error {
 			Namespace:          i.targetNamespace(),
 			Labels:             i.defaultLabels(),
 			Configs:            append(append(configs, secrets...), configMaps...),
-			Ports:              i.revision.Spec.Ports,
+			Ports:              i.ports(),
 			Replicas:           i.divideReplicas(i.target().Scale.Default),
 			Image:              i.image(),
 			Resources:          i.target().Resources,
@@ -368,7 +383,7 @@ func (i *Incarnation) taggedRoutes(privateGateway string, serviceHost string) []
 		return http
 	}
 	overrideLabel := fmt.Sprintf("pin/%s", i.appName())
-	for _, port := range i.revision.Spec.Ports {
+	for _, port := range i.ports() {
 		matches := []istiov1alpha3.HTTPMatchRequest{{
 			// mesh traffic from same tag'd service with and test tag
 			SourceLabels: map[string]string{

--- a/pkg/controller/releasemanager/syncer.go
+++ b/pkg/controller/releasemanager/syncer.go
@@ -156,7 +156,7 @@ func (r *ResourceSyncer) syncApp(ctx context.Context) error {
 	}
 
 	for _, incarnation := range incarnations {
-		for _, port := range incarnation.revision.Spec.Ports {
+		for _, port := range incarnation.ports() {
 			_, ok := portMap[port.Name]
 			if !ok {
 				portMap[port.Name] = port


### PR DESCRIPTION
Hello @ddbenson, @dnelson, @eblume, @silverlyra, @matkam, @micahnoland, @tonymeng, 

Please review the following commits I made in branch 'dokipen/20190917094127-per-target-hosts':

- **Make revision.spec.ports omitempty** (0fcb628190bf54356d5d02ea358edde286dbb6fd)

- **Don't require target.port field in revision yaml** (cfdaa6587766178653632fecb111570396e0fd96)

- **Revert "Revert "Move ports to target configuration in revision (#123)" (#125)"** (0e88c0817c5edf12c91431389775d6bd3e4bfd91)
This reverts commit 2274719f7cb475b3298241ff7f41391f3878622a.


R=@ddbenson
R=@dnelson
R=@eblume
R=@silverlyra
R=@matkam
R=@micahnoland
R=@tonymeng