### PR TITLE
Round up when dividing replicas by cluster

### DIFF
--- a/pkg/controller/releasemanager/incarnation_controller.go
+++ b/pkg/controller/releasemanager/incarnation_controller.go
@@ -2,6 +2,7 @@ package releasemanager
 
 import (
 	"context"
+	"math"
 
 	picchuv1alpha1 "go.medium.engineering/picchu/pkg/apis/picchu/v1alpha1"
 	"go.medium.engineering/picchu/pkg/controller/utils"
@@ -79,7 +80,7 @@ func (i *IncarnationController) applyPlan(ctx context.Context, name string, p pl
 func (i *IncarnationController) divideReplicas(count int32, percent int32) int32 {
 	denominator := utils.Max(i.fleetSize, 1)
 	percent = utils.Min(100, percent)
-	answer := int32((float64(percent) / float64(100)) * (float64(count) / float64(denominator)))
+	answer := int32(math.Ceil((float64(percent) / float64(100)) * (float64(count) / float64(denominator))))
 	i.log.Info("divideReplicas", "count", count, "percent", percent, "fleetSize", i.fleetSize, "answer", answer, "denominator", denominator)
 	return utils.Max(answer, 1)
 }

--- a/pkg/controller/releasemanager/incarnation_controller_test.go
+++ b/pkg/controller/releasemanager/incarnation_controller_test.go
@@ -1,0 +1,22 @@
+package releasemanager
+
+import (
+	T "testing"
+
+	"go.medium.engineering/picchu/pkg/test"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDivideReplicas(t *T.T) {
+	log := test.MustNewLogger()
+	out := IncarnationController{
+		fleetSize: 4,
+		log:       log,
+	}
+	// 5 are required, so each cluster should get 2 for a total of 8
+	// since 1 would be 4 and 4 < 5
+	assert.Equal(t, int32(2), out.divideReplicas(5, 100))
+	assert.Equal(t, int32(1), out.divideReplicas(5, 80))
+	assert.Equal(t, int32(2), out.divideReplicas(5, 81))
+}


### PR DESCRIPTION
Hello @ddbenson, @dnelson, @eblume, @silverlyra, @matkam, @micahnoland, @tonymeng, 

Please review the following commits I made in branch 'dokipen/20191015094522-ceil-replicas':

- **Round up when dividing replicas by cluster** (e55dcedbce74604ed63f1bd907bc026f42b1460e)


R=@ddbenson
R=@dnelson
R=@eblume
R=@silverlyra
R=@matkam
R=@micahnoland
R=@tonymeng