### PR TITLE
canarying releases get rate incremented

### DIFF
--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -518,11 +518,6 @@ func (i *Incarnation) secondsSinceRevision() float64 {
 	return latency.Seconds()
 }
 
-func (i *Incarnation) IsCanary() bool {
-	currentStatus := i.status.State.Current
-	return currentStatus == string(canaried) || currentStatus == string(canarying)
-}
-
 // IncarnationCollection helps us collect and select appropriate incarnations
 type IncarnationCollection struct {
 	// Incarnations key'd on revision.spec.app.tag

--- a/pkg/controller/releasemanager/syncer.go
+++ b/pkg/controller/releasemanager/syncer.go
@@ -280,16 +280,16 @@ func (r *ResourceSyncer) prepareRevisionsAndRules() ([]rmplan.Revision, []monito
 	for i, incarnation := range incarnations {
 		status := incarnation.status
 		oldCurrent := status.CurrentPercent
-
-		if firstNonCanary == -1 && !incarnation.IsCanary() {
-			firstNonCanary = i
-		}
+		currentState := State(status.State.Current)
 
 		// what this means in practice is that only the latest "releasing" revision will be incremented,
 		// the remaining will either stay the same or be decremented.
 		// "canaying" releases also get some traffic
+		if firstNonCanary == -1 && currentState != canaried && currentState != canarying {
+			firstNonCanary = i
+		}
 		var max uint32
-		if incarnation.status.State.Current == string(canarying) || i == firstNonCanary {
+		if currentState == canarying || i == firstNonCanary {
 			max = percRemaining
 		} else {
 			max = status.CurrentPercent

--- a/pkg/controller/releasemanager/syncer.go
+++ b/pkg/controller/releasemanager/syncer.go
@@ -281,11 +281,15 @@ func (r *ResourceSyncer) prepareRevisionsAndRules() ([]rmplan.Revision, []monito
 		status := incarnation.status
 		oldCurrent := status.CurrentPercent
 
-		// what this means in practice is that only the latest "releasing" revision will be incremented,
-		// the remaining will either stay the same or be decremented.
-		var max uint32
 		if firstNonCanary == -1 && !incarnation.IsCanary() {
 			firstNonCanary = i
+		}
+
+		// what this means in practice is that only the latest "releasing" revision will be incremented,
+		// the remaining will either stay the same or be decremented.
+		// "canaying" releases also get some traffic
+		var max uint32
+		if incarnation.status.State.Current == string(canarying) || i == firstNonCanary {
 			max = percRemaining
 		} else {
 			max = status.CurrentPercent


### PR DESCRIPTION
Hello @dokipen, @ddbenson, @dnelson, @silverlyra, @micahnoland, @tonymeng, 

Please review the following commits I made in branch 'matkam/rate-increment-canaying':

- **canarying releases get rate incremented** (f7e4a6991e4e3eda942d0a9cca19a70c31de1b87)


R=@dokipen
R=@ddbenson
R=@dnelson
R=@silverlyra
R=@micahnoland
R=@tonymeng