### PR TITLE
Make promrule sync non-fatal

### DIFF
--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -215,7 +215,7 @@ func (i *Incarnation) sync(ctx context.Context) error {
 }
 
 func (i *Incarnation) syncCanaryRules(ctx context.Context) error {
-	return i.controller.applyPlan(ctx, "Sync Canary Rules", &rmplan.SyncAlerts{
+	err := i.controller.applyPlan(ctx, "Sync Canary Rules", &rmplan.SyncAlerts{
 		App:                    i.appName(),
 		Namespace:              i.targetNamespace(),
 		Tag:                    i.tag,
@@ -223,19 +223,27 @@ func (i *Incarnation) syncCanaryRules(ctx context.Context) error {
 		ServiceLevelObjectives: i.target().ServiceLevelObjectives,
 		AlertType:              rmplan.Canary,
 	})
+	if err != nil {
+		i.log.Info("Syncing canary rules failed")
+	}
+	return nil
 }
 
 func (i *Incarnation) deleteCanaryRules(ctx context.Context) error {
-	return i.controller.applyPlan(ctx, "Delete Canary Rules", &rmplan.DeleteAlerts{
+	err := i.controller.applyPlan(ctx, "Delete Canary Rules", &rmplan.DeleteAlerts{
 		App:       i.appName(),
 		Namespace: i.targetNamespace(),
 		Tag:       i.tag,
 		AlertType: rmplan.Canary,
 	})
+	if err != nil {
+		i.log.Info("Deleting canary rules failed")
+	}
+	return nil
 }
 
 func (i *Incarnation) syncSLIRules(ctx context.Context) error {
-	return i.controller.applyPlan(ctx, "Sync SLI Rules", &rmplan.SyncAlerts{
+	err := i.controller.applyPlan(ctx, "Sync SLI Rules", &rmplan.SyncAlerts{
 		App:                    i.appName(),
 		Namespace:              i.targetNamespace(),
 		Tag:                    i.tag,
@@ -243,15 +251,23 @@ func (i *Incarnation) syncSLIRules(ctx context.Context) error {
 		ServiceLevelObjectives: i.target().ServiceLevelObjectives,
 		AlertType:              rmplan.SLI,
 	})
+	if err != nil {
+		i.log.Info("SLI rule sync failed")
+	}
+	return nil
 }
 
 func (i *Incarnation) deleteSLIRules(ctx context.Context) error {
-	return i.controller.applyPlan(ctx, "Delete SLI Rules", &rmplan.DeleteAlerts{
+	err := i.controller.applyPlan(ctx, "Delete SLI Rules", &rmplan.DeleteAlerts{
 		App:       i.appName(),
 		Namespace: i.targetNamespace(),
 		Tag:       i.tag,
 		AlertType: rmplan.SLI,
 	})
+	if err != nil {
+		i.log.Info("Delete SLI rule failed")
+	}
+	return nil
 }
 
 func (i *Incarnation) scale(ctx context.Context) error {

--- a/pkg/controller/releasemanager/plan/syncApp.go
+++ b/pkg/controller/releasemanager/plan/syncApp.go
@@ -81,7 +81,8 @@ func (p *SyncApp) Apply(ctx context.Context, cli client.Client, scalingFactor fl
 		}
 	} else {
 		if err := plan.CreateOrUpdate(ctx, log, cli, prometheusRule); err != nil {
-			return err
+			log.Info("Applying Prom Rules Failed")
+			// return err
 		}
 	}
 


### PR DESCRIPTION

Hello @ddbenson, @dnelson, @eblume, @silverlyra, @matkam, @micahnoland, @tonymeng, 

Please review the following commits I made in branch 'dokipen/20191025144509-no-prom':

- **Make promrule sync non-fatal** (0c72299ef8ac7e98a125d23299b28ff8dead24e4)


R=@ddbenson
R=@dnelson
R=@eblume
R=@silverlyra
R=@matkam
R=@micahnoland
R=@tonymeng

:bulb: testing on sandbox. not merging this, but want you all to take a look