### PR TITLE
More Aggressive Ramping

### DIFF
--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -479,7 +479,7 @@ func (i *Incarnation) divideReplicas(count int32) int32 {
 	if release.Eligible {
 		// since we sync before incrementing, we'll just err on the side of
 		// caution and use the next increment percent.
-		perc = int32(i.status.CurrentPercent + release.Rate.Increment*2)
+		perc = int32(i.status.CurrentPercent + release.Rate.Increment*4)
 	}
 	return i.controller.divideReplicas(count, perc)
 }

--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -494,6 +494,14 @@ func (i *Incarnation) currentPercentTarget(max uint32) uint32 {
 		}
 		return i.target().Canary.Percent
 	}
+	if i.target() != nil {
+		desired := i.divideReplicas(*i.target().Scale.Min)
+		current := i.status.Scale.Current
+		ratio := float64(current) / float64(desired)
+		i.log.Info("Calling linear scale", "desired", i.divideReplicas(*i.target().Scale.Min), "current", i.status.Scale.Current, "ratio", ratio)
+	} else {
+		i.log.Info("No target")
+	}
 	return LinearScale(*i, max, time.Now())
 }
 

--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -475,7 +475,7 @@ func (i *Incarnation) taggedRoutes(privateGateway string, serviceHost string) []
 
 func (i *Incarnation) divideReplicas(count int32) int32 {
 	release := i.target().Release
-	perc := int32(100)
+	perc := int32(1)
 	if release.Eligible {
 		// since we sync before incrementing, we'll just err on the side of
 		// caution and use the next increment percent.

--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -479,7 +479,7 @@ func (i *Incarnation) divideReplicas(count int32) int32 {
 	if release.Eligible {
 		// since we sync before incrementing, we'll just err on the side of
 		// caution and use the next increment percent.
-		perc = int32(i.status.CurrentPercent + release.Rate.Increment)
+		perc = int32(i.status.CurrentPercent + release.Rate.Increment*2)
 	}
 	return i.controller.divideReplicas(count, perc)
 }

--- a/pkg/controller/releasemanager/state.go
+++ b/pkg/controller/releasemanager/state.go
@@ -85,13 +85,14 @@ func NewDeploymentStateManager(deployment Deployment) *DeploymentStateManager {
 
 func (s *DeploymentStateManager) tick(ctx context.Context) error {
 	current := s.deployment.getStatus().State.Current
-	s.deployment.getLog().Info("Advancing state", "tag", s.deployment.getStatus().Tag, "current", current)
 	state, err := handlers[current](ctx, s.deployment)
+	if current != string(state) {
+		s.deployment.getLog().Info("Advancing state", "tag", s.deployment.getStatus().Tag, "previous", current, "current", state)
+	}
 	if err != nil {
 		return err
 	}
 	s.deployment.setState(string(state))
-	s.deployment.getLog().Info("Advanced state", "tag", s.deployment.getStatus().Tag, "current", string(state))
 	return nil
 }
 

--- a/pkg/controller/releasemanager/syncer_test.go
+++ b/pkg/controller/releasemanager/syncer_test.go
@@ -19,6 +19,7 @@ func createTestIncarnation(tag string, currentState State, currentPercent int) *
 	delaySeconds := int64(0)
 	scaleMin := int32(1)
 	return &Incarnation{
+		log: logf.Log.WithName("incarnation_syncer_test"),
 		tag: tag,
 		revision: &picchuv1alpha1.Revision{
 			Spec: picchuv1alpha1.RevisionSpec{

--- a/pkg/controller/revision/revision_controller.go
+++ b/pkg/controller/revision/revision_controller.go
@@ -344,7 +344,6 @@ func (r *ReconcileRevision) syncReleaseManager(log logr.Logger, revision *picchu
 		}
 		status.AddReleaseManagerStatus(*rm.RevisionStatus(revision.Spec.App.Tag))
 
-		log.Info("Checking for garbage collection")
 		rmCount++
 		for _, rl := range rm.Status.Revisions {
 			if rl.GitTimestamp == nil {
@@ -365,8 +364,6 @@ func (r *ReconcileRevision) syncReleaseManager(log logr.Logger, revision *picchu
 				} else {
 					log.Info("Expiration not reached", "Expiration", expiration, "GitTimestamp", rl.GitTimestamp, "Ttl", rl.TTL)
 				}
-			} else {
-				log.Info("Tag doesn't match", "StateTag", rl.Tag, "Tag", revision.Spec.App.Tag)
 			}
 		}
 		rstatus.AddTarget(status)


### PR DESCRIPTION
Hello @ddbenson, @dnelson, @silverlyra, @matkam, @micahnoland, @tonymeng, 

Please review the following commits I made in branch 'dokipen/20191028103934-ramp-safety':

- **Cleanup some logs and add logs around IsReconciled** (637bd680b5ff09ca1c5118679fde760c31574c28)

- **Ramp more aggressively to make up for resource caching in k8s** (608dab69d2e5439e4a235f5a0998e2784a87939f)

- **Don't ramp non-release eligible past 1% of min** (1d0c3832f7ce92595239b6d266c1cb69fb174c15)


R=@ddbenson
R=@dnelson
R=@silverlyra
R=@matkam
R=@micahnoland
R=@tonymeng