### PR TITLE
Don't increase a revision's scale unless fully deployed

### DIFF
--- a/pkg/controller/releasemanager/syncer.go
+++ b/pkg/controller/releasemanager/syncer.go
@@ -315,7 +315,14 @@ func (r *ResourceSyncer) prepareRevisionsAndRules() ([]rmplan.Revision, []monito
 			panic("Assertion failed")
 		}
 		incarnation.updateCurrentPercent(current)
-		r.log.Info("CurrentPercentage Update", "Tag", incarnation.tag, "Old", oldCurrent, "Current", current)
+		r.log.Info(
+			"CurrentPercentage Update",
+			"Tag", incarnation.tag,
+			"Old", oldCurrent,
+			"Current", current,
+			"desiredReplicas", status.Scale.Desired,
+			"currentReplicas", status.Scale.Current,
+		)
 		if current <= 0 {
 			incarnation.setReleaseEligible(false)
 		}

--- a/pkg/controller/releasemanager/syncer_test.go
+++ b/pkg/controller/releasemanager/syncer_test.go
@@ -146,7 +146,7 @@ func assertIncarnationPercent(
 	}
 }
 
-func TestPrepareRevisionsAndRulesBadAdditon(t *tt.T) {
+func TestPrepareRevisionsAndRulesBadAddition(t *tt.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 


### PR DESCRIPTION
Hello @dokipen, @ddbenson, @dnelson, @matkam, @micahnoland, @tonymeng, 

Please review the following commits I made in branch 'silverlyra/tutu-scale':

- **Don't increase a revision's scale unless fully deployed** (6535a67963cd040c2d1007877c5430b543fb4a14)

- **Fix typo in test name** (7387af10ab4d75d9f17867fdbd919582a0a3cb74)

- **Add hook to configure test incarnations** (8092ff4e87a31491bd355a6b098be62029a84b0e)


R=@dokipen
R=@ddbenson
R=@dnelson
R=@matkam
R=@micahnoland
R=@tonymeng