### PR TITLE
Don't worry about releasemanagers when deleting clusters

### DIFF
--- a/pkg/controller/cluster/cluster_controller.go
+++ b/pkg/controller/cluster/cluster_controller.go
@@ -151,24 +151,9 @@ func (r *ReconcileCluster) Reconcile(request reconcile.Request) (reconcile.Resul
 		}
 		return reconcile.Result{RequeueAfter: r.config.RequeueAfter}, nil
 	}
-	// TODO(bob): See if setting cluster and revision as owner of
-	// releasemanager automatically resolves this complex ordering
 	if !instance.IsFinalized() {
-		rml := &picchuv1alpha1.ReleaseManagerList{}
-		opts := client.
-			MatchingLabels(map[string]string{picchuv1alpha1.LabelCluster: instance.Name}).
-			InNamespace(instance.Namespace)
 		if r.config.ManageRoute53 {
 			route53.Delete(instance)
-		}
-		if err := r.client.List(context.TODO(), opts, rml); err != nil {
-			return reconcile.Result{}, err
-		}
-		// Give the releasemanagers enough time to delete remote resources
-		// before deleting this Cluster, since releasemanager relies on cluster
-		// for remote client configuration.
-		if len(rml.Items) > 0 {
-			return reconcile.Result{RequeueAfter: r.config.RequeueAfter}, r.client.Update(context.TODO(), instance)
 		}
 		instance.Finalize()
 		return reconcile.Result{}, r.client.Update(context.TODO(), instance)


### PR DESCRIPTION
Hello @ddbenson, @dnelson, @silverlyra, @matkam, @micahnoland, @tonymeng, 

Please review the following commits I made in branch 'dokipen/20191111134927-MED-5404':

- **Don't worry about releasemanagers when deleting clusters** (66fc42e0394318d1dabc5cb5e993c4d63ba706d5)


R=@ddbenson
R=@dnelson
R=@silverlyra
R=@matkam
R=@micahnoland
R=@tonymeng