### PR TITLE
Allow external tests to fail explicitly

### DIFF
--- a/pkg/apis/picchu/v1alpha1/revision_test.go
+++ b/pkg/apis/picchu/v1alpha1/revision_test.go
@@ -31,6 +31,17 @@ func TestExternalTestPending(t *testing.T) {
 	assert.False(t, target.IsExternalTestPending())
 }
 
+func TestExternalTestFailed(t *testing.T) {
+	target := &RevisionTarget{}
+	target.ExternalTest.Enabled = true
+
+	target.ExternalTest.Completed = true
+	assert.False(t, target.IsExternalTestSuccessful())
+
+	target.ExternalTest.Succeeded = true
+	assert.True(t, target.IsExternalTestSuccessful())
+}
+
 func TestCanaryTestPending(t *testing.T) {
 	target := &RevisionTarget{}
 	dt := metav1.Time{}

--- a/pkg/apis/picchu/v1alpha1/revision_types.go
+++ b/pkg/apis/picchu/v1alpha1/revision_types.go
@@ -110,6 +110,7 @@ type ExternalTest struct {
 	Enabled   bool `json:"enabled"`
 	Started   bool `json:"started"`
 	Completed bool `json:"completed"`
+	Succeeded bool `json:"succeeded,omitempty"`
 }
 
 type Canary struct {
@@ -201,6 +202,11 @@ func (r *Revision) HasTarget(name string) bool {
 
 func (r *RevisionTarget) IsExternalTestPending() bool {
 	return r.ExternalTest.Enabled && !r.ExternalTest.Completed
+}
+
+func (r *RevisionTarget) IsExternalTestSuccessful() bool {
+	t := &r.ExternalTest
+	return t.Enabled && t.Completed && t.Succeeded
 }
 
 func (r *RevisionTarget) IsCanaryPending(startTime *metav1.Time) bool {

--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -159,6 +159,16 @@ func (i *Incarnation) isTestStarted() bool {
 	return i.target().ExternalTest.Started
 }
 
+func (i *Incarnation) didTestSucceed() bool {
+	if !i.hasRevision() {
+		return false
+	}
+	if i.revision.Spec.Failed {
+		return false
+	}
+	return i.target().IsExternalTestSuccessful()
+}
+
 // Remotely sync the incarnation for it's current state
 func (i *Incarnation) sync(ctx context.Context) error {
 	// Revision deleted

--- a/pkg/controller/releasemanager/mock_deployment.go
+++ b/pkg/controller/releasemanager/mock_deployment.go
@@ -6,10 +6,11 @@ package releasemanager
 
 import (
 	context "context"
+	reflect "reflect"
+
 	logr "github.com/go-logr/logr"
 	gomock "github.com/golang/mock/gomock"
 	v1alpha1 "go.medium.engineering/picchu/pkg/apis/picchu/v1alpha1"
-	reflect "reflect"
 )
 
 // MockDeployment is a mock of Deployment interface
@@ -215,6 +216,20 @@ func (m *MockDeployment) isTestStarted() bool {
 func (mr *MockDeploymentMockRecorder) isTestStarted() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "isTestStarted", reflect.TypeOf((*MockDeployment)(nil).isTestStarted))
+}
+
+// didTestSucceed mocks base method
+func (m *MockDeployment) didTestSucceed() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "didTestSucceed")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// didTestSucceed indicates an expected call of didTestSucceed
+func (mr *MockDeploymentMockRecorder) didTestSucceed() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "didTestSucceed", reflect.TypeOf((*MockDeployment)(nil).didTestSucceed))
 }
 
 // peakPercent mocks base method

--- a/pkg/controller/releasemanager/state.go
+++ b/pkg/controller/releasemanager/state.go
@@ -70,6 +70,7 @@ type Deployment interface {
 	isDeployed() bool
 	isTestPending() bool
 	isTestStarted() bool
+	didTestSucceed() bool
 	currentPercent() uint32
 	peakPercent() uint32
 	isCanaryPending() bool
@@ -164,7 +165,10 @@ func Testing(ctx context.Context, deployment Deployment) (State, error) {
 		return failing, nil
 	}
 	if !deployment.isTestPending() {
-		return tested, nil
+		if deployment.didTestSucceed() {
+			return tested, nil
+		}
+		return failing, nil
 	}
 	return testing, nil
 }


### PR DESCRIPTION
Hello @dokipen, @ddbenson, @dnelson, @matkam, @micahnoland, @tonymeng, 

Please review the following commits I made in branch 'silverlyra/explicit-external-test-failure':

- **Allow external tests to fail explicitly** (551a600a3aad28a8b2935f601e70683e95213320)


R=@dokipen
R=@ddbenson
R=@dnelson
R=@matkam
R=@micahnoland
R=@tonymeng

:point_right: Without this, we can’t detect an external test suite failing in a way that doesn’t trigger a monitoring alarm (e.g., `200 OK` with unexpected content).