### PR TITLE
Don't retire releases just because they don't have enough pods to ramp from 0%

### DIFF
--- a/pkg/controller/releasemanager/syncer.go
+++ b/pkg/controller/releasemanager/syncer.go
@@ -364,7 +364,9 @@ func (r *ResourceSyncer) prepareRevisionsAndRules() ([]rmplan.Revision, []monito
 			"currentState", status.State.Current,
 		)
 
-		if currentPercent <= 0 && currentState != releasing {
+		percRemaining -= currentPercent
+
+		if currentPercent <= 0 && percRemaining <= 0 {
 			r.log.Info(
 				"Setting incarnation release-eligibility to false; will trigger retirement",
 				"tag", incarnation.tag,
@@ -375,7 +377,6 @@ func (r *ResourceSyncer) prepareRevisionsAndRules() ([]rmplan.Revision, []monito
 			incarnation.setReleaseEligible(false)
 		}
 
-		percRemaining -= currentPercent
 		tagRoutingHeader := ""
 		if incarnation.revision != nil {
 			tagRoutingHeader = incarnation.revision.Spec.TagRoutingHeader


### PR DESCRIPTION
Hello @ddbenson, @dnelson, @silverlyra, @matkam, @micahnoland, @tonymeng, 

Please review the following commits I made in branch 'dokipen/20191113191347-no-retire-tutu':

- **Don't retire releases just because they don't have enough pods to ramp from 0%** (73ad2e505d06e12219162ec94e5aa8a31e09c052)


R=@ddbenson
R=@dnelson
R=@silverlyra
R=@matkam
R=@micahnoland
R=@tonymeng