### PR TITLE
Scale down replicas when ramping down

### DIFF
--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -473,7 +473,7 @@ func (i *Incarnation) taggedRoutes(privateGateway string, serviceHost string) []
 func (i *Incarnation) divideReplicas(count int32) int32 {
 	release := i.target().Release
 	perc := int32(100)
-	if release.Eligible {
+	if release.Eligible || i.status.CurrentPercent > 0 {
 		// since we sync before incrementing, we'll just err on the side of
 		// caution and use the next increment percent.
 		perc = int32(i.status.CurrentPercent + release.Rate.Increment)

--- a/pkg/plan/composite.go
+++ b/pkg/plan/composite.go
@@ -20,7 +20,9 @@ func All(plans ...Plan) Plan {
 }
 
 func (p *compositePlan) Apply(ctx context.Context, cli client.Client, scalingFactor float64, log logr.Logger) error {
-	for _, plan := range p.plans {
+	for i := range p.plans {
+		plan := p.plans[i]
+		log.Info("Applying Plan", "Plan", plan)
 		if err := plan.Apply(ctx, cli, scalingFactor, log); err != nil {
 			return err
 		}


### PR DESCRIPTION
Hello @ddbenson, @dnelson, @silverlyra, @matkam, @micahnoland, @tonymeng, 

Please review the following commits I made in branch 'dokipen/20191118121540-scale-down':

- **Scale down replicas when ramping down** (4d6c354cc17e0b5feede19c9a9b325a410c983c3)


R=@ddbenson
R=@dnelson
R=@silverlyra
R=@matkam
R=@micahnoland
R=@tonymeng