### PR TITLE
Remove long log message that causes dd log parsing errors

### DIFF
--- a/pkg/controller/releasemanager/observe/observer.go
+++ b/pkg/controller/releasemanager/observe/observer.go
@@ -95,6 +95,7 @@ func (o *ConcurrentObserver) Observe(ctx context.Context, namespace string) (*Ob
 		o := observations[i]
 		obs = obs.Combine(&o)
 	}
-	o.log.Info("Concurrent observations collected", "Observation", obs)
+	// TODO(bob): this is too big to log, maybe only display replicasets with >0 values.
+	// o.log.Info("Concurrent observations collected", "Observation", obs)
 	return obs, nil
 }


### PR DESCRIPTION
Hello @ddbenson, @dnelson, @silverlyra, @matkam, @micahnoland, @tonymeng, 

Please review the commits I made in branch 'dokipen/20191125123821-remove-long-log'.

R=@ddbenson
R=@dnelson
R=@silverlyra
R=@matkam
R=@micahnoland
R=@tonymeng