### PR TITLE
backwards compatible ReleaseManagerRevisionScaleStatus crd fields

### DIFF
--- a/deploy/crds/picchu.medium.engineering_releasemanagers_crd.yaml
+++ b/deploy/crds/picchu.medium.engineering_releasemanagers_crd.yaml
@@ -86,18 +86,15 @@ spec:
                     type: string
                   scale:
                     properties:
-                      current:
+                      Current:
                         format: int32
                         type: integer
-                      desired:
+                      Desired:
                         format: int32
                         type: integer
-                      peak:
+                      Peak:
                         format: int32
                         type: integer
-                    required:
-                    - current
-                    - desired
                     type: object
                   state:
                     properties:

--- a/pkg/apis/picchu/v1alpha1/releasemanager_types.go
+++ b/pkg/apis/picchu/v1alpha1/releasemanager_types.go
@@ -83,9 +83,9 @@ func (r *ReleaseManagerRevisionStateStatus) EqualTo(other *ReleaseManagerRevisio
 }
 
 type ReleaseManagerRevisionScaleStatus struct {
-	Current int32 `json:"current"`
-	Desired int32 `json:"desired"`
-	Peak    int32 `json:"peak,omitempty"`
+	Current int32 `json:"Current,omitempty"`
+	Desired int32 `json:"Desired,omitempty"`
+	Peak    int32 `json:"Peak,omitempty"`
 }
 
 func (r *ReleaseManager) RevisionStatus(tag string) *ReleaseManagerRevisionStatus {


### PR DESCRIPTION
Hello @dokipen, @ddbenson, @dnelson, @silverlyra, @micahnoland, @tonymeng, 

Please review the commits I made in branch 'matkam/compatible-rev-scale-status'.

R=@dokipen
R=@ddbenson
R=@dnelson
R=@silverlyra
R=@micahnoland
R=@tonymeng