### PR TITLE
Scale HPA targets by traffic percentage

### DIFF
--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -578,11 +578,7 @@ func (i *Incarnation) divideReplicas(count int32) int32 {
 // not underprovisioned when it recieves more traffic.
 func (i *Incarnation) targetScale() float64 {
 	status := i.getStatus()
-	if status.State.Current == "deploying" || status.State.Current == "deployed" || status.State.Current == "pendingrelease" {
-		return 1.0
-	}
-
-	if !i.target().Release.Eligible || i.status.CurrentPercent == 0 {
+	if status.State.Current != "releasing" || i.status.CurrentPercent == 0 {
 		return 1.0
 	}
 

--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -578,12 +578,12 @@ func (i *Incarnation) divideReplicas(count int32) int32 {
 // not underprovisioned when it recieves more traffic.
 func (i *Incarnation) targetScale() float64 {
 	status := i.getStatus()
-	if status.State.Current != "releasing" || i.status.CurrentPercent == 0 {
+	current := i.status.CurrentPercent
+	next := math.Min(float64(current+i.target().Release.Rate.Increment), 100.0)
+
+	if status.State.Current != "releasing" || current <= 0 || current >= 100 {
 		return 1.0
 	}
-
-	current := i.status.CurrentPercent
-	next := float64(current + i.target().Release.Rate.Increment)
 
 	return float64(current) / next
 }

--- a/pkg/controller/releasemanager/incarnation_test.go
+++ b/pkg/controller/releasemanager/incarnation_test.go
@@ -87,3 +87,17 @@ func assertExternalTestStatus(
 	assert.Equal(t, expectedStatus, testIncarnation.getExternalTestStatus())
 	assert.Equal(t, expectedTimeout, testIncarnation.isTimingOut())
 }
+
+func TestIncarnation_targetScale(t *ttesting.T) {
+	testIncarnation := createTestIncarnation("test", testing, 10)
+	testIncarnation.status.State.Current = "releasing"
+	testIncarnation.revision.Spec.Targets[0].Release.Rate.Increment = 10
+	testIncarnation.status.CurrentPercent = 0
+	assert.Equal(t, 1.0, testIncarnation.targetScale())
+	testIncarnation.status.CurrentPercent = 10
+	assert.Equal(t, 0.5, testIncarnation.targetScale())
+	testIncarnation.status.CurrentPercent = 90
+	assert.Equal(t, 0.9, testIncarnation.targetScale())
+	testIncarnation.status.CurrentPercent = 100
+	assert.Equal(t, 1.0, testIncarnation.targetScale())
+}

--- a/pkg/plan/common.go
+++ b/pkg/plan/common.go
@@ -237,6 +237,7 @@ func CreateOrUpdate(
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      typed.Name,
 				Namespace: typed.Namespace,
+				Labels:    typed.Labels,
 			},
 		}
 		op, err := controllerutil.CreateOrUpdate(ctx, cli, hpa, func() error {


### PR DESCRIPTION
Hello @ddbenson, @dnelson, @silverlyra, @matkam, @micahnoland, 

Please review the commits I made in branch 'dokipen/20200214165843-target-scaling'.

R=@ddbenson
R=@dnelson
R=@silverlyra
R=@matkam
R=@micahnoland

:bulb: This reduces hpa thresholds during ramp up according to the formula $configuredThreshold * $nextPercentage / $currentPercentage, to prevent underprovisioning during scaling.