### PR TITLE
Fix tagged ServiceLevels when no SLOs are defined

### DIFF
--- a/pkg/controller/releasemanager/plan/syncTaggedServiceLevels.go
+++ b/pkg/controller/releasemanager/plan/syncTaggedServiceLevels.go
@@ -60,18 +60,20 @@ func (p *SyncTaggedServiceLevels) serviceLevels() (*slov1alpha1.ServiceLevelList
 		}
 	}
 
-	serviceLevel := &slov1alpha1.ServiceLevel{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      p.taggedServiceLevelName(),
-			Namespace: p.Namespace,
-			Labels:    p.Labels,
-		},
-		Spec: slov1alpha1.ServiceLevelSpec{
-			ServiceLevelName:       p.App,
-			ServiceLevelObjectives: slos,
-		},
+	if len(slos) > 0 {
+		serviceLevel := &slov1alpha1.ServiceLevel{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      p.taggedServiceLevelName(),
+				Namespace: p.Namespace,
+				Labels:    p.Labels,
+			},
+			Spec: slov1alpha1.ServiceLevelSpec{
+				ServiceLevelName:       p.App,
+				ServiceLevelObjectives: slos,
+			},
+		}
+		sl = append(sl, *serviceLevel)
 	}
-	sl = append(sl, *serviceLevel)
 
 	sll.Items = sl
 	return sll, nil


### PR DESCRIPTION
Hello @dokipen, @ddbenson, @dnelson, @silverlyra, @matkam, 

Please review the commits I made in branch 'micahnoland/fix-tagged-servicelevels'.

Fixes a bug where tagged ServiceLevels are created when SLOs are not defined.

R=@dokipen
R=@ddbenson
R=@dnelson
R=@silverlyra
R=@matkam