### PR TITLE
Fixing alertRule regression

### DIFF
--- a/pkg/controller/releasemanager/syncer.go
+++ b/pkg/controller/releasemanager/syncer.go
@@ -426,14 +426,14 @@ func (r *ResourceSyncer) garbageCollection(ctx context.Context) error {
 func (r *ResourceSyncer) prepareAlertRules() []monitoringv1.Rule {
 	alertRules := []monitoringv1.Rule{}
 
-	if len(r.incarnations.deployed()) == 0 {
-		return alertRules
-	}
-
-	alertable := r.incarnations.alertable()
-	for _, i := range alertable {
-		alertRules = i.target().AlertRules
-		break
+	if len(r.incarnations.deployed()) > 0 {
+		alertable := r.incarnations.alertable()
+		for _, i := range alertable {
+			if i.target() != nil {
+				alertRules = i.target().AlertRules
+				break
+			}
+		}
 	}
 
 	return alertRules
@@ -448,6 +448,7 @@ func (r *ResourceSyncer) prepareServiceMonitors() []*picchuv1alpha1.ServiceMonit
 		for _, i := range alertable {
 			if i.target() != nil {
 				sm = i.target().ServiceMonitors
+				break
 			}
 		}
 	}


### PR DESCRIPTION
Hello @dokipen, @ddbenson, @dnelson, @silverlyra, @matkam, 

Please review the commits I made in branch 'micahnoland/alerts-fix'.

I think this will fix the issue with `alertRules` not being created correctly. My local testing had the rules created.

R=@dokipen
R=@ddbenson
R=@dnelson
R=@silverlyra
R=@matkam