### PR TITLE
Don't prematurely retire the most recent canarying revisions

### DIFF
--- a/pkg/controller/releasemanager/syncer.go
+++ b/pkg/controller/releasemanager/syncer.go
@@ -449,14 +449,21 @@ func (r *ResourceSyncer) prepareRevisions() []rmplan.Revision {
 	count := len(incarnations)
 
 	firstNonCanary := -1
+	firstNonCanaryTag := ""
 	for i, incarnation := range incarnations {
 		status := incarnation.status
 		oldCurrentPercent := status.CurrentPercent
 		currentState := State(status.State.Current)
 
 		if firstNonCanary == -1 && currentState != canaried && currentState != canarying {
-			r.log.Info("Found first ramping release", "firstNonCanary", i)
+			r.log.Info(
+				"Found first ramping release",
+				"firstNonCanary", i,
+				"Tag", incarnation.tag,
+				"currentState", status.State.Current,
+			)
 			firstNonCanary = i
+			firstNonCanaryTag = incarnation.tag
 		}
 
 		// what this means in practice is that only the latest "releasing" revision will be incremented,
@@ -493,6 +500,7 @@ func (r *ResourceSyncer) prepareRevisions() []rmplan.Revision {
 			r.log.Info(
 				"Setting incarnation release-eligibility to false; will trigger retirement",
 				"Tag", incarnation.tag,
+				"rampingTag", firstNonCanaryTag,
 				"oldCurrentPercent", oldCurrentPercent,
 				"currentPercent", currentPercent,
 				"currentState", status.State.Current,

--- a/pkg/controller/releasemanager/syncer.go
+++ b/pkg/controller/releasemanager/syncer.go
@@ -496,7 +496,7 @@ func (r *ResourceSyncer) prepareRevisions() []rmplan.Revision {
 
 		percRemaining -= currentPercent
 
-		if currentPercent <= 0 && i > firstNonCanary {
+		if currentPercent <= 0 && firstNonCanary != -1 && i > firstNonCanary {
 			r.log.Info(
 				"Setting incarnation release-eligibility to false; will trigger retirement",
 				"Tag", incarnation.tag,


### PR DESCRIPTION
Hello @dokipen, @ddbenson, @dnelson, @matkam, @micahnoland, 

Please review the commits I made in branch 'silverlyra/y-u-no'.

R=@dokipen
R=@ddbenson
R=@dnelson
R=@matkam
R=@micahnoland


We do the `!= 1` check above when setting `max`, but not here; looks like this is how revisions are getting `releaseEligible: false` as soon as they enter the `canarying` state.