### PR TITLE
Merge portInfo objects to override in targets

### DIFF
--- a/deploy/crds/picchu.medium.engineering_revisions_crd.yaml
+++ b/deploy/crds/picchu.medium.engineering_revisions_crd.yaml
@@ -68,8 +68,6 @@ spec:
                     items:
                       type: string
                     type: array
-                  httpsRedirect:
-                    type: boolean
                   ingressPort:
                     format: int32
                     type: integer
@@ -974,8 +972,6 @@ spec:
                           items:
                             type: string
                           type: array
-                        httpsRedirect:
-                          type: boolean
                         ingressPort:
                           format: int32
                           type: integer

--- a/pkg/apis/picchu/v1alpha1/common.go
+++ b/pkg/apis/picchu/v1alpha1/common.go
@@ -61,9 +61,39 @@ type PortInfo struct {
 	ContainerPort int32           `json:"containerPort,omitempty"`
 	Protocol      corev1.Protocol `json:"protocol,omitempty"`
 	Mode          PortMode        `json:"mode"`
-	HttpsRedirect bool            `json:"httpsRedirect,omitempty"`
 
 	Istio IstioPortConfig `json:"istio,omitempty"`
+}
+
+func (p *PortInfo) Merge(other *PortInfo) *PortInfo {
+	merged := p.DeepCopy()
+	SetPortDefaults(merged)
+	SetPortDefaults(other)
+	if other.Name != "" {
+		merged.Name = other.Name
+	}
+	if len(other.Hosts) > 0 {
+		merged.Hosts = other.Hosts
+	}
+	if other.IngressPort != defaultPortIngressPort {
+		merged.IngressPort = other.IngressPort
+	}
+	if other.Port != defaultPortPort {
+		merged.Port = other.Port
+	}
+	if other.ContainerPort != defaultPortContainerPort {
+		merged.ContainerPort = other.ContainerPort
+	}
+	if other.Protocol != defaultPortProtocol {
+		merged.Protocol = other.Protocol
+	}
+	if other.Mode != defaultPortMode {
+		merged.Mode = other.Mode
+	}
+	if other.Istio.HTTP.Retries != nil {
+		merged.Istio.HTTP.Retries = other.Istio.HTTP.Retries
+	}
+	return merged
 }
 
 type IstioPortConfig struct {

--- a/pkg/apis/picchu/v1alpha1/revision_test.go
+++ b/pkg/apis/picchu/v1alpha1/revision_test.go
@@ -57,3 +57,37 @@ func TestCanaryTestPending(t *testing.T) {
 	lastSecond := metav1.Time{time.Now().Add(-time.Second)}
 	assert.False(t, target.IsCanaryPending(&lastSecond))
 }
+
+func TestPortInfoMerge(t *testing.T) {
+	a := &PortInfo{
+		Name:          "http",
+		Hosts:         nil,
+		IngressPort:   443,
+		Port:          80,
+		ContainerPort: 80,
+		Protocol:      "TCP",
+		Mode:          "private",
+		Istio:         IstioPortConfig{},
+	}
+	b := &PortInfo{
+		Name:          "http",
+		Hosts:         []string{"yahoo.com"},
+		IngressPort:   443,
+		Port:          80,
+		ContainerPort: 80,
+		Protocol:      "TCP",
+		Mode:          "public",
+		Istio:         IstioPortConfig{},
+	}
+	expected := &PortInfo{
+		Name:          "http",
+		Hosts:         []string{"yahoo.com"},
+		IngressPort:   443,
+		Port:          80,
+		ContainerPort: 80,
+		Protocol:      "TCP",
+		Mode:          "public",
+		Istio:         IstioPortConfig{},
+	}
+	assert.Equal(t, expected, a.Merge(b))
+}

--- a/pkg/controller/releasemanager/incarnation_test.go
+++ b/pkg/controller/releasemanager/incarnation_test.go
@@ -101,3 +101,51 @@ func TestIncarnation_targetScale(t *ttesting.T) {
 	testIncarnation.status.CurrentPercent = 100
 	assert.Equal(t, 1.0, testIncarnation.targetScale())
 }
+
+func TestIncarnation_PortInfoMerging(t *ttesting.T) {
+	i := createTestIncarnation("test", testing, 10)
+	i.revision.Spec.Ports = []v1alpha1.PortInfo{
+		{
+			Name: "http",
+			Port: 8080,
+		},
+		{
+			Name: "status",
+			Port: 4444,
+		},
+	}
+	assert.Equal(t, 1, len(i.revision.Spec.Targets))
+	i.revision.Spec.Targets[0].Ports = []v1alpha1.PortInfo{
+		{
+			Name:  "http",
+			Hosts: []string{"www.medm.io"},
+		},
+		{
+			Name:  "grpc",
+			Hosts: []string{"grpc.medm.io"},
+		},
+	}
+
+	for j := range i.revision.Spec.Ports {
+		v1alpha1.SetPortDefaults(&i.revision.Spec.Ports[j])
+	}
+	for j := range i.revision.Spec.Targets[0].Ports {
+		v1alpha1.SetPortDefaults(&i.revision.Spec.Targets[0].Ports[j])
+	}
+
+	ports := i.ports()
+	assert.Equal(t, 3, len(ports))
+	for _, port := range ports {
+		switch port.Name {
+		case "http":
+			assert.EqualValues(t, 8080, port.Port)
+			assert.Equal(t, []string{"www.medm.io"}, port.Hosts)
+		case "grpc":
+			assert.EqualValues(t, 80, port.Port)
+			assert.Equal(t, []string{"grpc.medm.io"}, port.Hosts)
+		case "status":
+			assert.EqualValues(t, 4444, port.Port)
+			assert.Nil(t, port.Hosts)
+		}
+	}
+}

--- a/pkg/controller/releasemanager/plan/syncApp_test.go
+++ b/pkg/controller/releasemanager/plan/syncApp_test.go
@@ -56,7 +56,6 @@ var (
 				ContainerPort: 5000,
 				Protocol:      corev1.ProtocolTCP,
 				Mode:          picchuv1alpha1.PortPrivate,
-				HttpsRedirect: true,
 			},
 			{
 				Name:          "status",
@@ -373,7 +372,6 @@ func TestDomains(t *testing.T) {
 				ContainerPort: 5000,
 				Protocol:      corev1.ProtocolTCP,
 				Mode:          picchuv1alpha1.PortPublic,
-				HttpsRedirect: true,
 				Hosts:         []string{"www.doki-pen.org"},
 			},
 			{


### PR DESCRIPTION
This allows something like this:
```yaml
spec:
  ports:
  - name: "http"
    port: 8080
  targets:
  - name: production
    ports:
    - name: "http"
      hosts:
      - my.cool.hostname
```

The like named ports would be merged for the target production giving:
```yaml
name: "http"
port: 8080
hosts:
- my.cool.hostname
```

Also removes the httpsRedirect cruft with is on by default in this branch (plum).

What do you think? Good or dumb?

Some negative aspects: merging won't work right if a port value is set in the revision, but then set to default in the target override, which could be confusing. Default values in the targets section are ignored and not merged.