### PR TITLE
Setup public port hosts in private ingress too

### DIFF
--- a/pkg/controller/releasemanager/plan/syncApp.go
+++ b/pkg/controller/releasemanager/plan/syncApp.go
@@ -140,10 +140,8 @@ func (p *SyncApp) ingressHosts(
 		}
 	}
 
-	if port.Mode == mode {
-		for _, host := range port.Hosts {
-			hostMap[host] = true
-		}
+	for _, host := range port.Hosts {
+		hostMap[host] = true
 	}
 
 	hosts := make([]string, 0, len(hostMap))

--- a/pkg/controller/releasemanager/plan/syncApp_test.go
+++ b/pkg/controller/releasemanager/plan/syncApp_test.go
@@ -459,9 +459,11 @@ func TestHosts(t *testing.T) {
 		"website-internal.doki-pen.org",
 	}, plan.publicHosts(publicPort, cluster))
 	assert.ElementsMatch(t, []string{
+		"www.doki-pen.org",
 		"website-internal.dkpn.io",
 	}, plan.privateHosts(publicPort, cluster))
 	assert.ElementsMatch(t, []string{
+		"www.dkpn.io",
 		"website-internal.doki-pen.org",
 	}, plan.publicHosts(privatePort, cluster))
 	assert.ElementsMatch(t, []string{


### PR DESCRIPTION
Hello @ddbenson, @dnelson, @silverlyra, @matkam, @micahnoland, 

Please review the commits I made in branch 'dokipen/20200415062315-add-public-hosts-to-private-ingress-too'.

R=@ddbenson
R=@dnelson
R=@silverlyra
R=@matkam
R=@micahnoland

This will allow us to transition from private to public cleanly