### PR TITLE
Allowing custom metric name for request rate autoscaling

### DIFF
--- a/deploy/crds/picchu.medium.engineering_revisions_crd.yaml
+++ b/deploy/crds/picchu.medium.engineering_revisions_crd.yaml
@@ -1238,6 +1238,8 @@ spec:
                       minReadySeconds:
                         format: int32
                         type: integer
+                      requestsRateMetric:
+                        type: string
                       targetCPUUtilizationPercentage:
                         format: int32
                         type: integer

--- a/pkg/apis/picchu/v1alpha1/common.go
+++ b/pkg/apis/picchu/v1alpha1/common.go
@@ -83,6 +83,7 @@ type ScaleInfo struct {
 	Default                        int32   `json:"default,omitempty"`
 	Max                            int32   `json:"max,omitempty"`
 	TargetCPUUtilizationPercentage *int32  `json:"targetCPUUtilizationPercentage,omitempty"`
+	RequestsRateMetric             string  `json:"requestsRateMetric,omitempty"`
 	TargetRequestsRate             *string `json:"targetRequestsRate,omitempty"`
 	MinReadySeconds                int32   `json:"minReadySeconds,omitempty"`
 }

--- a/pkg/apis/picchu/v1alpha1/source_defaults.go
+++ b/pkg/apis/picchu/v1alpha1/source_defaults.go
@@ -12,6 +12,7 @@ const (
 	defaultReleaseGcTTLSeconds     = int64(5 * 24 * 60 * 60)
 	defaultScaleDefault            = int32(1)
 	defaultScaleMax                = int32(1)
+	defaultRequestsRateMetric      = "istio_requests_rate"
 
 	defaultPortIngressPort   = int32(443)
 	defaultPortContainerPort = int32(80)
@@ -82,5 +83,8 @@ func SetScaleDefaults(scale *ScaleInfo) {
 	}
 	if scale.Max == 0 {
 		scale.Max = defaultScaleMax
+	}
+	if scale.RequestsRateMetric == "" {
+		scale.RequestsRateMetric = defaultRequestsRateMetric
 	}
 }

--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -462,6 +462,7 @@ func (i *Incarnation) genScalePlan(ctx context.Context) *rmplan.ScaleRevision {
 		Max:                max,
 		Labels:             i.defaultLabels(),
 		CPUTarget:          cpuTarget,
+		RequestsRateMetric: i.target().Scale.RequestsRateMetric,
 		RequestsRateTarget: requestsRateTarget,
 	}
 }

--- a/pkg/controller/releasemanager/plan/scaleRevision.go
+++ b/pkg/controller/releasemanager/plan/scaleRevision.go
@@ -3,8 +3,9 @@ package plan
 import (
 	"context"
 	"errors"
-	picchuv1alpha1 "go.medium.engineering/picchu/pkg/apis/picchu/v1alpha1"
 	"math"
+
+	picchuv1alpha1 "go.medium.engineering/picchu/pkg/apis/picchu/v1alpha1"
 
 	"go.medium.engineering/picchu/pkg/controller/utils"
 	"go.medium.engineering/picchu/pkg/plan"
@@ -23,10 +24,11 @@ type ScaleRevision struct {
 	Max                int32
 	Labels             map[string]string
 	CPUTarget          *int32
+	RequestsRateMetric string
 	RequestsRateTarget *resource.Quantity
 }
 
-const RequestsRateMetric = "istio_requests_rate"
+const DefaultRequestsRateMetric = "istio_requests_rate"
 
 func (p *ScaleRevision) Apply(ctx context.Context, cli client.Client, cluster *picchuv1alpha1.Cluster, log logr.Logger) error {
 	var metrics = []autoscaling.MetricSpec{}
@@ -47,11 +49,16 @@ func (p *ScaleRevision) Apply(ctx context.Context, cli client.Client, cluster *p
 
 	if p.RequestsRateTarget != nil {
 		rateTarget := *p.RequestsRateTarget
+		requestsRateMetric := p.RequestsRateMetric
+		if requestsRateMetric == "" {
+			requestsRateMetric = DefaultRequestsRateMetric
+		}
+
 		metrics = append(metrics, autoscaling.MetricSpec{
 			Type: autoscaling.PodsMetricSourceType,
 			Pods: &autoscaling.PodsMetricSource{
 				Metric: autoscaling.MetricIdentifier{
-					Name: RequestsRateMetric,
+					Name: requestsRateMetric,
 				},
 				Target: autoscaling.MetricTarget{
 					AverageValue: &rateTarget,

--- a/pkg/controller/releasemanager/plan/scaleRevision.go
+++ b/pkg/controller/releasemanager/plan/scaleRevision.go
@@ -28,8 +28,6 @@ type ScaleRevision struct {
 	RequestsRateTarget *resource.Quantity
 }
 
-const DefaultRequestsRateMetric = "istio_requests_rate"
-
 func (p *ScaleRevision) Apply(ctx context.Context, cli client.Client, cluster *picchuv1alpha1.Cluster, log logr.Logger) error {
 	var metrics = []autoscaling.MetricSpec{}
 
@@ -49,16 +47,11 @@ func (p *ScaleRevision) Apply(ctx context.Context, cli client.Client, cluster *p
 
 	if p.RequestsRateTarget != nil {
 		rateTarget := *p.RequestsRateTarget
-		requestsRateMetric := p.RequestsRateMetric
-		if requestsRateMetric == "" {
-			requestsRateMetric = DefaultRequestsRateMetric
-		}
-
 		metrics = append(metrics, autoscaling.MetricSpec{
 			Type: autoscaling.PodsMetricSourceType,
 			Pods: &autoscaling.PodsMetricSource{
 				Metric: autoscaling.MetricIdentifier{
-					Name: requestsRateMetric,
+					Name: p.RequestsRateMetric,
 				},
 				Target: autoscaling.MetricTarget{
 					AverageValue: &rateTarget,

--- a/pkg/controller/releasemanager/plan/scaleRevision_test.go
+++ b/pkg/controller/releasemanager/plan/scaleRevision_test.go
@@ -76,6 +76,7 @@ func TestScaleRevisionByRequestsRate(t *testing.T) {
 		Namespace:          "testnamespace",
 		Min:                4,
 		Max:                10,
+		RequestsRateMetric: "request_rate",
 		RequestsRateTarget: quantity,
 		Labels:             map[string]string{},
 	}
@@ -93,6 +94,7 @@ func TestScaleRevisionByRequestsRate(t *testing.T) {
 		case *autoscaling.HorizontalPodAutoscaler:
 			return o.Spec.MaxReplicas == 5 &&
 				o.Spec.Metrics[0].Pods.Target.AverageValue.String() == "5" &&
+				o.Spec.Metrics[0].Pods.Metric.Name == "request_rate" &&
 				len(o.Spec.Metrics) == 1
 		default:
 			return false


### PR DESCRIPTION
Hello @dokipen, @ddbenson, @dnelson, @silverlyra, @matkam, 

Please review the commits I made in branch 'micahnoland/custom-scale-metrics'.

R=@dokipen
R=@ddbenson
R=@dnelson
R=@silverlyra
R=@matkam


Adds the ability to specify a custom metric name to use with the request rate HPA.