### PR TITLE
Better error handling for releasemanager controller

### DIFF
--- a/pkg/controller/releasemanager/releasemanager_controller.go
+++ b/pkg/controller/releasemanager/releasemanager_controller.go
@@ -3,9 +3,10 @@ package releasemanager
 import (
 	"context"
 	"fmt"
+	"time"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"time"
 
 	picchuv1alpha1 "go.medium.engineering/picchu/pkg/apis/picchu/v1alpha1"
 	"go.medium.engineering/picchu/pkg/controller/releasemanager/observe"
@@ -208,7 +209,7 @@ func (r *ReconcileReleaseManager) Reconcile(request reconcile.Request) (reconcil
 
 	clusters, err := r.getClustersByFleet(ctx, rm.Namespace, rm.Spec.Fleet)
 	if err != nil {
-		rmLog.Error(err, "Failed to get clusters for fleet", "Fleet.Name", rm.Spec.Fleet)
+		return r.requeue(rmLog, fmt.Errorf("Failed to get clusters for fleet %s: %w", rm.Spec.Fleet, err))
 	}
 	clusterInfo := ClusterInfoList{}
 	for _, cluster := range clusters {
@@ -232,7 +233,7 @@ func (r *ReconcileReleaseManager) Reconcile(request reconcile.Request) (reconcil
 
 	deliveryClusters, err := r.getClustersByFleet(ctx, rm.Namespace, r.config.ServiceLevelsFleet)
 	if err != nil {
-		rmLog.Error(err, "Failed to get delivery clusters for fleet", "Fleet.Name", r.config.ServiceLevelsFleet)
+		return r.requeue(rmLog, fmt.Errorf("Failed to get delivery clusters for fleet %s: %w", r.config.ServiceLevelsFleet, err))
 	}
 	deliveryClusterInfo := ClusterInfoList{}
 	for _, cluster := range deliveryClusters {

--- a/pkg/controller/releasemanager/syncer.go
+++ b/pkg/controller/releasemanager/syncer.go
@@ -14,9 +14,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -42,24 +39,6 @@ type ResourceSyncer struct {
 	reconciler      *ReconcileReleaseManager
 	log             logr.Logger
 	picchuConfig    utils.Config
-}
-
-func (r *ResourceSyncer) getSecrets(ctx context.Context, opts *client.ListOptions) ([]runtime.Object, error) {
-	secrets := &corev1.SecretList{}
-	err := r.deliveryClient.List(ctx, secrets, opts)
-	if errors.IsNotFound(err) {
-		return []runtime.Object{}, nil
-	}
-	return utils.MustExtractList(secrets), err
-}
-
-func (r *ResourceSyncer) getConfigMaps(ctx context.Context, opts *client.ListOptions) ([]runtime.Object, error) {
-	configMaps := &corev1.ConfigMapList{}
-	err := r.deliveryClient.List(ctx, configMaps, opts)
-	if errors.IsNotFound(err) {
-		return []runtime.Object{}, nil
-	}
-	return utils.MustExtractList(configMaps), err
 }
 
 func (r *ResourceSyncer) sync(ctx context.Context) (rs []picchuv1alpha1.ReleaseManagerRevisionStatus, err error) {


### PR DESCRIPTION
Hello @dokipen, @ddbenson, @dnelson, @silverlyra, @matkam, 

Please review the commits I made in branch 'micahnoland/fix-requeue'.

R=@dokipen
R=@ddbenson
R=@dnelson
R=@silverlyra
R=@matkam

* Removing some dead code, `getConfigMaps()` and `getSecrets()` live in `incarnation_controller.go` now.
* Wrapping errors and requeuing in releasemanager `Reconcile()`