### PR TITLE
Fix generating short default hosts

### DIFF
--- a/pkg/controller/releasemanager/plan/syncApp.go
+++ b/pkg/controller/releasemanager/plan/syncApp.go
@@ -131,12 +131,16 @@ func (p *SyncApp) ingressHosts(
 	defaultDomains []string,
 ) []string {
 	hostMap := map[string]bool{}
+	fleetSuffix := fmt.Sprintf("-%s", p.Fleet)
 
 	for _, domain := range defaultDomains {
-		name := p.Namespace
-		hostMap[fmt.Sprintf("%s.%s", name, domain)] = true
+		hostMap[fmt.Sprintf("%s.%s", p.Namespace, domain)] = true
+
 		if p.Target == p.Fleet {
 			hostMap[fmt.Sprintf("%s.%s", p.App, domain)] = true
+		} else if strings.HasSuffix(p.Namespace, fleetSuffix) {
+			basename := strings.TrimSuffix(p.Namespace, fleetSuffix)
+			hostMap[fmt.Sprintf("%s.%s", basename, domain)] = true
 		}
 	}
 

--- a/pkg/controller/releasemanager/plan/syncApp_test.go
+++ b/pkg/controller/releasemanager/plan/syncApp_test.go
@@ -457,17 +457,21 @@ func TestHosts(t *testing.T) {
 	assert.ElementsMatch(t, []string{
 		"www.doki-pen.org",
 		"website-internal.doki-pen.org",
+		"website.doki-pen.org",
 	}, plan.publicHosts(publicPort, cluster))
 	assert.ElementsMatch(t, []string{
 		"www.doki-pen.org",
 		"website-internal.dkpn.io",
+		"website.dkpn.io",
 	}, plan.privateHosts(publicPort, cluster))
 	assert.ElementsMatch(t, []string{
 		"www.dkpn.io",
 		"website-internal.doki-pen.org",
+		"website.doki-pen.org",
 	}, plan.publicHosts(privatePort, cluster))
 	assert.ElementsMatch(t, []string{
 		"www.dkpn.io",
 		"website-internal.dkpn.io",
+		"website.dkpn.io",
 	}, plan.privateHosts(privatePort, cluster))
 }


### PR DESCRIPTION
Hello @dokipen, @ddbenson, @dnelson, @matkam, @micahnoland, 

Please review the commits I made in branch 'silverlyra/fleet-suffix'.

R=@dokipen
R=@ddbenson
R=@dnelson
R=@matkam
R=@micahnoland

:point_right: This better supports apps with multiple production targets. (kbfd already expects these hostnames to work.)