### PR TITLE
Exposing additional Istio Port configuration fields to Revisions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ platform_temp = $(subst -, ,$(ARCH))
 GOOS = $(word 1, $(platform_temp))
 GOARCH = $(word 2, $(platform_temp))
 export GOROOT = $(shell go env GOROOT)
+export GO111MODULE = on
 
 .PHONY: all build generate deepcopy defaulter openapi clientset crds ci test verify
 

--- a/deploy/crds/picchu.medium.engineering_revisions_crd.yaml
+++ b/deploy/crds/picchu.medium.engineering_revisions_crd.yaml
@@ -3039,7 +3039,11 @@ spec:
                                       type: integer
                                     perTryTimeout:
                                       type: string
+                                    retryOn:
+                                      type: string
                                   type: object
+                                timeout:
+                                  type: string
                               type: object
                           type: object
                         mode:

--- a/pkg/apis/picchu/v1alpha1/common.go
+++ b/pkg/apis/picchu/v1alpha1/common.go
@@ -73,10 +73,12 @@ type IstioPortConfig struct {
 type Retries struct {
 	Attempts      int32            `json:"attempts,omitempty"`
 	PerTryTimeout *metav1.Duration `json:"perTryTimeout,omitempty"`
+	RetryOn       *string          `json:"retryOn,omitempty"`
 }
 
 type IstioHTTPPortConfig struct {
-	Retries *Retries `json:"retries,omitempty"`
+	Retries *Retries         `json:"retries,omitempty"`
+	Timeout *metav1.Duration `json:"timeout,omitempty"`
 }
 
 type ScaleInfo struct {

--- a/pkg/apis/picchu/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/picchu/v1alpha1/zz_generated.deepcopy.go
@@ -541,6 +541,11 @@ func (in *IstioHTTPPortConfig) DeepCopyInto(out *IstioHTTPPortConfig) {
 		*out = new(Retries)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Timeout != nil {
+		in, out := &in.Timeout, &out.Timeout
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 
@@ -1010,6 +1015,11 @@ func (in *Retries) DeepCopyInto(out *Retries) {
 	if in.PerTryTimeout != nil {
 		in, out := &in.PerTryTimeout, &out.PerTryTimeout
 		*out = new(v1.Duration)
+		**out = **in
+	}
+	if in.RetryOn != nil {
+		in, out := &in.RetryOn, &out.RetryOn
+		*out = new(string)
 		**out = **in
 	}
 	return

--- a/pkg/controller/releasemanager/plan/syncApp.go
+++ b/pkg/controller/releasemanager/plan/syncApp.go
@@ -301,8 +301,16 @@ func (p *SyncApp) makeRoute(
 		if http.Retries.PerTryTimeout != nil {
 			retries.PerTryTimeout = types.DurationProto(http.Retries.PerTryTimeout.Duration)
 		}
+		if http.Retries.RetryOn != nil {
+			retries.RetryOn = *http.Retries.RetryOn
+		}
+	}
+	var timeout *types.Duration
+	if http.Timeout != nil {
+		timeout = types.DurationProto(http.Timeout.Duration)
 	}
 	return &istio.HTTPRoute{
+		Timeout: timeout,
 		Retries: retries,
 		Match:   match,
 		Route:   route,


### PR DESCRIPTION

Adds `retryOn` and route `timeout` as configurable Istio HTTP route options in the `Revision` spec.