### PR TITLE
Apply envFrom for sidecars

### DIFF
--- a/pkg/controller/releasemanager/plan/syncRevision.go
+++ b/pkg/controller/releasemanager/plan/syncRevision.go
@@ -201,6 +201,7 @@ func (p *SyncRevision) syncReplicaSet(
 	containers = append(containers, p.Sidecars...)
 
 	for i := range containers {
+		containers[i].EnvFrom = envs
 		containers[i].Env = p.EnvVars
 	}
 

--- a/pkg/controller/releasemanager/plan/syncRevision_test.go
+++ b/pkg/controller/releasemanager/plan/syncRevision_test.go
@@ -434,11 +434,13 @@ func TestSyncRevisionWithCreateAndSecret(t *testing.T) {
 
 	expectedRs := defaultExpectedReplicaSet.DeepCopy()
 	expectedRs.TypeMeta = metav1.TypeMeta{}
-	expectedRs.Spec.Template.Spec.Containers[0].EnvFrom = []corev1.EnvFromSource{{
-		ConfigMapRef: &corev1.ConfigMapEnvSource{
-			LocalObjectReference: corev1.LocalObjectReference{Name: "testconfigmap"},
-		},
-	}}
+	for i := range expectedRs.Spec.Template.Spec.Containers {
+		expectedRs.Spec.Template.Spec.Containers[i].EnvFrom = []corev1.EnvFromSource{{
+			ConfigMapRef: &corev1.ConfigMapEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "testconfigmap"},
+			},
+		}}
+	}
 
 	copy := *defaultRevisionPlan
 	plan := &copy


### PR DESCRIPTION
Applies the same envFrom to the sidecars as the primary container.