### PR TITLE
Remove deprecated rateInfo and make geometric default scaling strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ tags
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 secrets/*
 .idea
+cmd/manager/picchuDebug

--- a/pkg/apis/picchu/v1alpha1/common.go
+++ b/pkg/apis/picchu/v1alpha1/common.go
@@ -126,7 +126,7 @@ type ScaleInfo struct {
 	Worker *WorkerScaleInfo `json:"worker,omitempty"`
 }
 
-func (s *ScaleInfo) TargetReqeustsRateQuantity() (*resource.Quantity, error) {
+func (s *ScaleInfo) TargetRequestsRateQuantity() (*resource.Quantity, error) {
 	if s.TargetRequestsRate == nil {
 		return nil, nil
 	}

--- a/pkg/apis/picchu/v1alpha1/source_defaults.go
+++ b/pkg/apis/picchu/v1alpha1/source_defaults.go
@@ -59,13 +59,6 @@ func SetReleaseDefaults(release *ReleaseInfo) {
 	if release.ScalingStrategy == "" {
 		release.ScalingStrategy = defaultReleaseScalingStrategy
 	}
-	if release.Rate.Increment == 0 {
-		release.Rate.Increment = defaultReleaseRateIncrement
-	}
-	if release.Rate.DelaySeconds == nil {
-		delay := defaultReleaseRateDelaySeconds
-		release.Rate.DelaySeconds = &delay
-	}
 	if release.TTL == 0 {
 		release.TTL = defaultReleaseGcTTLSeconds
 	}

--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -437,7 +437,7 @@ func (i *Incarnation) deleteTaggedServiceLevels(ctx context.Context) error {
 }
 
 func (i *Incarnation) genScalePlan(ctx context.Context) *rmplan.ScaleRevision {
-	requestsRateTarget, err := i.target().Scale.TargetReqeustsRateQuantity()
+	requestsRateTarget, err := i.target().Scale.TargetRequestsRateQuantity()
 	if err != nil {
 		i.log.Error(err, "Failed to parse targetRequestsRate", "TargetRequestsRate", i.target().Scale.TargetRequestsRate)
 	}

--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -709,20 +709,19 @@ func (i *Incarnation) divideReplicas(count int32) int32 {
 		return 1
 	}
 
-	var perc int32 = 100
+	var perc uint32 = 100
 	if status.State.Current == "canarying" {
-		perc = int32(i.target().Canary.Percent)
+		perc = i.target().Canary.Percent
 	} else {
 		release := i.target().Release
-		increment := release.Rate.Increment
 		if release.Eligible || i.status.CurrentPercent > 0 {
 			// since we sync before incrementing, we'll just err on the side of
 			// caution and use the next increment percent.
-			perc = int32(i.status.CurrentPercent + increment)
+			perc = NextIncrement(*i, i.target().Release.Max)
 		}
 	}
 
-	return i.controller.divideReplicas(count, perc)
+	return i.controller.divideReplicas(count, int32(perc))
 }
 
 // targetScale is used to scale HPA targets to prepare for next
@@ -731,7 +730,7 @@ func (i *Incarnation) divideReplicas(count int32) int32 {
 // not under-provisioned when it receives more traffic.
 func (i *Incarnation) targetScale() float64 {
 	status := i.getStatus()
-	next := float64(NextIncrement(*i, 100, time.Time{}))
+	next := float64(NextIncrement(*i, 100))
 	current := i.currentPercent()
 
 	if status.State.Current != "releasing" || current <= 0 || current >= 100 {
@@ -770,10 +769,7 @@ func (i *Incarnation) updateCurrentPercent(current uint32) {
 
 func (i *Incarnation) secondsSinceRevision() float64 {
 	start := i.revision.CreationTimestamp
-	rate := i.target().Release.Rate
-	delay := *rate.DelaySeconds
-	increment := rate.Increment
-	expected := time.Second * time.Duration(delay*int64(math.Ceil(100.0/float64(increment))))
+	expected := ExpectedReleaseLatency(*i, i.target().Release.Max)
 	latency := time.Since(start.Time) - expected
 	return latency.Seconds()
 }

--- a/pkg/controller/releasemanager/scaling/geometric.go
+++ b/pkg/controller/releasemanager/scaling/geometric.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func GeometricNextIncrement(st ScalableTarget, max uint32, t time.Time, log logr.Logger) uint32 {
+func GeometricNextIncrement(st ScalableTarget, max uint32, log logr.Logger) uint32 {
 	current := st.CurrentPercent()
 	release := st.ReleaseInfo()
 
@@ -22,12 +22,6 @@ func GeometricNextIncrement(st ScalableTarget, max uint32, t time.Time, log logr
 		return max
 	}
 
-	// Wait longer to scale
-	deadline := st.LastUpdated().Add(release.GeometricScaling.Delay.Duration)
-	if deadline.After(t) {
-		return current
-	}
-
 	next := current * release.GeometricScaling.Factor
 	if current < release.GeometricScaling.Start {
 		next = release.GeometricScaling.Start
@@ -41,15 +35,38 @@ func GeometricNextIncrement(st ScalableTarget, max uint32, t time.Time, log logr
 }
 
 func GeometricScale(st ScalableTarget, max uint32, t time.Time, log logr.Logger) uint32 {
-	desired := GeometricNextIncrement(st, max, t, log)
+	desired := GeometricNextIncrement(st, max, log)
+	current := st.CurrentPercent()
 
 	if desired <= st.CurrentPercent() {
 		return desired
+	}
+
+	// Wait longer to scale
+	release := st.ReleaseInfo()
+	deadline := st.LastUpdated().Add(release.GeometricScaling.Delay.Duration)
+	if deadline.After(t) {
+		return current
 	}
 
 	if st.CanRampTo(desired) {
 		return desired
 	}
 
-	return st.CurrentPercent()
+	return current
+}
+
+func GeometricExpectedReleaseLatency(st ScalableTarget, max uint32, log logr.Logger) time.Duration {
+	factor := st.ReleaseInfo().GeometricScaling.Factor
+	// because we start at start and not zero
+	iterations := 1
+	var currentPercent uint32 = st.ReleaseInfo().GeometricScaling.Start
+	for {
+		currentPercent = currentPercent * factor
+		iterations++
+		if currentPercent >= max {
+			break
+		}
+	}
+	return st.ReleaseInfo().GeometricScaling.Delay.Duration * time.Duration(iterations)
 }

--- a/pkg/controller/releasemanager/scaling/geometric_test.go
+++ b/pkg/controller/releasemanager/scaling/geometric_test.go
@@ -159,7 +159,6 @@ func TestGeometricScaling(t *testing.T) {
 					Delay:  &metav1.Duration{Duration: test.Delay},
 				},
 				LinearScaling: picchu.LinearScaling{},
-				Rate:          picchu.RateInfo{},
 				Schedule:      "always",
 				TTL:           86400,
 			}

--- a/pkg/controller/releasemanager/scaling/linear.go
+++ b/pkg/controller/releasemanager/scaling/linear.go
@@ -2,15 +2,29 @@ package scaling
 
 import (
 	"github.com/go-logr/logr"
+	"math"
 	"time"
 )
 
 // LinearScale scales a ScalableTarget linearly
 func LinearScale(st ScalableTarget, max uint32, t time.Time, log logr.Logger) uint32 {
-	desired := LinearNextIncrement(st, max, t, log)
+	desired := LinearNextIncrement(st, max, log)
+	current := st.CurrentPercent()
 
 	if desired <= st.CurrentPercent() {
 		return desired
+	}
+
+	release := st.ReleaseInfo()
+	duration := release.LinearScaling.Delay.Duration
+	// TODO(bob): remove
+	if release.Rate.DelaySeconds != nil {
+		duration = time.Duration(*release.Rate.DelaySeconds) * time.Second
+	}
+	deadline := st.LastUpdated().Add(duration)
+	// Wait longer to scale
+	if deadline.After(t) {
+		return current
 	}
 
 	if st.CanRampTo(desired) {
@@ -20,7 +34,7 @@ func LinearScale(st ScalableTarget, max uint32, t time.Time, log logr.Logger) ui
 	return st.CurrentPercent()
 }
 
-func LinearNextIncrement(st ScalableTarget, max uint32, t time.Time, log logr.Logger) uint32 {
+func LinearNextIncrement(st ScalableTarget, max uint32, log logr.Logger) uint32 {
 	current := st.CurrentPercent()
 	release := st.ReleaseInfo()
 
@@ -37,13 +51,11 @@ func LinearNextIncrement(st ScalableTarget, max uint32, t time.Time, log logr.Lo
 		return max
 	}
 
-	// Wait longer to scale
-	deadline := st.LastUpdated().Add(time.Duration(*release.Rate.DelaySeconds) * time.Second)
-	if deadline.After(t) {
-		return current
+	increment := release.LinearScaling.Increment
+	// TODO(bob): remove
+	if release.Rate.Increment > 0 {
+		increment = release.Rate.Increment
 	}
-
-	increment := release.Rate.Increment
 	next := current + increment
 
 	if next > max {
@@ -51,4 +63,20 @@ func LinearNextIncrement(st ScalableTarget, max uint32, t time.Time, log logr.Lo
 	}
 
 	return next
+}
+
+func LinearExpectedReleaseLatency(st ScalableTarget, max uint32, log logr.Logger) time.Duration {
+	release := st.ReleaseInfo()
+	increment := release.LinearScaling.Increment
+	// TODO(bob): remove
+	if release.Rate.Increment > 0 {
+		increment = release.Rate.Increment
+	}
+	duration := release.LinearScaling.Delay.Duration
+	// TODO(bob): remove
+	if release.Rate.DelaySeconds != nil {
+		duration = time.Duration(*release.Rate.DelaySeconds) * time.Second
+	}
+	iterations := math.Ceil(float64(max) / float64(increment))
+	return duration * time.Duration(iterations)
 }

--- a/pkg/controller/releasemanager/scaling/linear_test.go
+++ b/pkg/controller/releasemanager/scaling/linear_test.go
@@ -4,7 +4,7 @@ import (
 	testify "github.com/stretchr/testify/assert"
 	picchu "go.medium.engineering/picchu/pkg/apis/picchu/v1alpha1"
 	"go.medium.engineering/picchu/pkg/test"
-	"k8s.io/utils/pointer"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 	"time"
 
@@ -135,10 +135,9 @@ func TestLinearScaling(t *testing.T) {
 				Max:              test.Max,
 				ScalingStrategy:  picchu.ScalingStrategyLinear,
 				GeometricScaling: picchu.GeometricScaling{},
-				LinearScaling:    picchu.LinearScaling{},
-				Rate: picchu.RateInfo{
-					Increment:    test.Increment,
-					DelaySeconds: pointer.Int64Ptr(test.Delay),
+				LinearScaling: picchu.LinearScaling{
+					Increment: test.Increment,
+					Delay:     &metav1.Duration{Duration: time.Duration(test.Delay) * time.Second},
 				},
 				Schedule: "always",
 				TTL:      86400,

--- a/pkg/controller/releasemanager/syncer.go
+++ b/pkg/controller/releasemanager/syncer.go
@@ -468,8 +468,7 @@ func (r *ResourceSyncer) prepareRevisions() []rmplan.Revision {
 			r.log.Info(
 				"Percent target greater than percRemaining",
 				"current", currentPercent,
-				"percRemaining", percRemaining,
-				"increment", incarnation.target().Release.Rate.Increment)
+				"percRemaining", percRemaining)
 			panic("Assertion failed")
 		}
 		incarnation.updateCurrentPercent(currentPercent)


### PR DESCRIPTION
This PR has completely changed. Deprecated rate still exists until all apps are properly migrated.