### PR TITLE
[MED-26732] Delete WPA when retiring revision

### DIFF
--- a/pkg/controller/releasemanager/plan/deleteRevision.go
+++ b/pkg/controller/releasemanager/plan/deleteRevision.go
@@ -2,11 +2,12 @@ package plan
 
 import (
 	"context"
+
 	picchuv1alpha1 "go.medium.engineering/picchu/pkg/apis/picchu/v1alpha1"
 	"go.medium.engineering/picchu/pkg/controller/utils"
-	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -21,6 +22,7 @@ func (p *DeleteRevision) Apply(ctx context.Context, cli client.Client, cluster *
 		NewConfigMapList(),
 		NewReplicaSetList(),
 		NewHorizontalPodAutoscalerList(),
+		NewWorkerPodAutoscalerList(),
 	}
 
 	opts := &client.ListOptions{

--- a/pkg/controller/releasemanager/plan/deleteRevision_test.go
+++ b/pkg/controller/releasemanager/plan/deleteRevision_test.go
@@ -8,6 +8,7 @@ import (
 	"go.medium.engineering/picchu/pkg/test"
 
 	"github.com/golang/mock/gomock"
+	wpav1 "github.com/practo/k8s-worker-pod-autoscaler/pkg/apis/workerpodautoscaler/v1"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscaling "k8s.io/api/autoscaling/v2beta2"
@@ -72,6 +73,15 @@ func TestDeleteRevision(t *testing.T) {
 		},
 	}
 
+	wpas := []wpav1.WorkerPodAutoScaler{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "testwpa",
+				Namespace: "testnamespace",
+			},
+		},
+	}
+
 	m.
 		EXPECT().
 		List(ctx, mocks.InjectSecrets(secrets), mocks.ListOptions(opts)).
@@ -94,6 +104,11 @@ func TestDeleteRevision(t *testing.T) {
 		Times(1)
 	m.
 		EXPECT().
+		List(ctx, mocks.InjectWorkerPodAutoscalers(wpas), mocks.ListOptions(opts)).
+		Return(nil).
+		Times(1)
+	m.
+		EXPECT().
 		Delete(ctx, mocks.NamespacedName("testnamespace", "testsecret")).
 		Return(nil).
 		Times(1)
@@ -110,6 +125,11 @@ func TestDeleteRevision(t *testing.T) {
 	m.
 		EXPECT().
 		Delete(ctx, mocks.NamespacedName("testnamespace", "testhpa")).
+		Return(nil).
+		Times(1)
+	m.
+		EXPECT().
+		Delete(ctx, mocks.NamespacedName("testnamespace", "testwpa")).
 		Return(nil).
 		Times(1)
 

--- a/pkg/controller/releasemanager/plan/retireRevision.go
+++ b/pkg/controller/releasemanager/plan/retireRevision.go
@@ -2,10 +2,14 @@ package plan
 
 import (
 	"context"
-	"github.com/go-logr/logr"
+
 	picchuv1alpha1 "go.medium.engineering/picchu/pkg/apis/picchu/v1alpha1"
+
+	"github.com/go-logr/logr"
+	wpav1 "github.com/practo/k8s-worker-pod-autoscaler/pkg/apis/workerpodautoscaler/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -15,25 +19,41 @@ type RetireRevision struct {
 	Namespace string
 }
 
-func (p *RetireRevision) Apply(ctx context.Context, cli client.Client, cluster *picchuv1alpha1.Cluster, log logr.Logger) error {
-	rs := &appsv1.ReplicaSet{}
-	s := types.NamespacedName{p.Namespace, p.Tag}
-	err := cli.Get(ctx, s, rs)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		log.Error(err, "Failed to update replicaset to 0 replicas")
-		return err
+func (p *RetireRevision) Apply(ctx context.Context, cli client.Client, cluster *picchuv1alpha1.Cluster, log logr.Logger) (err error) {
+	namespacedName := types.NamespacedName{Namespace: p.Namespace, Name: p.Tag}
+	wpa := &wpav1.WorkerPodAutoScaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      p.Tag,
+			Namespace: p.Namespace,
+		},
 	}
-	if *rs.Spec.Replicas != 0 {
+	err = cli.Delete(ctx, wpa)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			log.Error(err, "Failed to delete WPA while retiring revisions",
+				"namespace", p.Namespace,
+				"tag", p.Tag,
+			)
+			return
+		}
+	}
+
+	rs := &appsv1.ReplicaSet{}
+	err = cli.Get(ctx, namespacedName, rs)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			log.Error(err, "Failed to update replicaset to 0 replicas")
+			return
+		}
+	} else if *rs.Spec.Replicas != 0 {
 		var r int32 = 0
 		rs.Spec.Replicas = &r
 		err = cli.Update(ctx, rs)
 		log.Info("ReplicaSet sync'd", "Type", "ReplicaSet", "Audit", true, "Content", rs, "Op", "updated")
 		if err != nil {
-			return err
+			return
 		}
 	}
+
 	return nil
 }

--- a/pkg/controller/releasemanager/plan/retireRevision.go
+++ b/pkg/controller/releasemanager/plan/retireRevision.go
@@ -30,7 +30,7 @@ func (p *RetireRevision) Apply(ctx context.Context, cli client.Client, cluster *
 	err = cli.Delete(ctx, wpa)
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			log.Error(err, "Failed to delete WPA while retiring revisions",
+			log.Error(err, "Failed to delete WPA while retiring revision",
 				"namespace", p.Namespace,
 				"tag", p.Tag,
 			)
@@ -42,7 +42,10 @@ func (p *RetireRevision) Apply(ctx context.Context, cli client.Client, cluster *
 	err = cli.Get(ctx, namespacedName, rs)
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			log.Error(err, "Failed to update replicaset to 0 replicas")
+			log.Error(err, "Failed to update replicaset to 0 replicas, while retiring revision",
+				"namespace", p.Namespace,
+				"tag", p.Tag,
+			)
 			return
 		}
 	} else if *rs.Spec.Replicas != 0 {

--- a/pkg/controller/releasemanager/plan/retireRevision_test.go
+++ b/pkg/controller/releasemanager/plan/retireRevision_test.go
@@ -9,8 +9,10 @@ import (
 	"go.medium.engineering/picchu/pkg/test"
 
 	"github.com/golang/mock/gomock"
+	wpav1 "github.com/practo/k8s-worker-pod-autoscaler/pkg/apis/workerpodautoscaler/v1"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -26,6 +28,19 @@ func TestRetireMissingRevision(t *testing.T) {
 	}
 	ok := client.ObjectKey{Name: "testtag", Namespace: "testnamespace"}
 	ctx := context.TODO()
+
+	wpa := &wpav1.WorkerPodAutoScaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rr.Tag,
+			Namespace: rr.Namespace,
+		},
+	}
+
+	m.
+		EXPECT().
+		Delete(ctx, mocks.UpdateWPAObjectMeta(wpa)).
+		Return(common.NotFoundError).
+		Times(1)
 
 	m.
 		EXPECT().
@@ -50,19 +65,18 @@ func TestRetireExistingRevision(t *testing.T) {
 	ctx := context.TODO()
 
 	var one int32 = 1
+	wpa := &wpav1.WorkerPodAutoScaler{
+		Spec: wpav1.WorkerPodAutoScalerSpec{
+			MinReplicas: &one,
+			MaxReplicas: &one,
+		},
+	}
 	rs := &appsv1.ReplicaSet{
 		Spec: appsv1.ReplicaSetSpec{
 			Replicas: &one,
 		},
 	}
-
-	m.
-		EXPECT().
-		Get(ctx, mocks.ObjectKey(ok), mocks.UpdateReplicaSetSpec(rs)).
-		Return(nil).
-		Times(1)
-
-	noreplicas := mocks.Callback(func(x interface{}) bool {
+	noReplicas := mocks.Callback(func(x interface{}) bool {
 		switch o := x.(type) {
 		case *appsv1.ReplicaSet:
 			return *o.Spec.Replicas == 0
@@ -73,7 +87,17 @@ func TestRetireExistingRevision(t *testing.T) {
 
 	m.
 		EXPECT().
-		Update(ctx, noreplicas).
+		Delete(ctx, mocks.UpdateWPASpec(wpa)).
+		Return(nil).
+		Times(1)
+	m.
+		EXPECT().
+		Get(ctx, mocks.ObjectKey(ok), mocks.UpdateReplicaSetSpec(rs)).
+		Return(nil).
+		Times(1)
+	m.
+		EXPECT().
+		Update(ctx, noReplicas).
 		Return(nil).
 		Times(1)
 

--- a/pkg/controller/releasemanager/plan/scaleRevision.go
+++ b/pkg/controller/releasemanager/plan/scaleRevision.go
@@ -53,7 +53,7 @@ func (p *ScaleRevision) Apply(ctx context.Context, cli client.Client, cluster *p
 }
 
 func (p *ScaleRevision) applyHPA(ctx context.Context, cli client.Client, log logr.Logger, scaledMin int32, scaledMax int32) error {
-	var metrics = []autoscaling.MetricSpec{}
+	var metrics []autoscaling.MetricSpec
 
 	if p.CPUTarget != nil {
 		cpuTarget := *p.CPUTarget

--- a/pkg/controller/releasemanager/plan/wrappers.go
+++ b/pkg/controller/releasemanager/plan/wrappers.go
@@ -1,6 +1,7 @@
 package plan
 
 import (
+	wpav1 "github.com/practo/k8s-worker-pod-autoscaler/pkg/apis/workerpodautoscaler/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscaling "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
@@ -28,6 +29,10 @@ type HorizontalPodAutoscalerList struct {
 	Item *autoscaling.HorizontalPodAutoscalerList
 }
 
+type WorkerPodAutoscalerList struct {
+	Item *wpav1.WorkerPodAutoScalerList
+}
+
 func NewSecretList() *SecretList {
 	return &SecretList{&corev1.SecretList{}}
 }
@@ -42,6 +47,10 @@ func NewReplicaSetList() *ReplicaSetList {
 
 func NewHorizontalPodAutoscalerList() *HorizontalPodAutoscalerList {
 	return &HorizontalPodAutoscalerList{&autoscaling.HorizontalPodAutoscalerList{}}
+}
+
+func NewWorkerPodAutoscalerList() *WorkerPodAutoscalerList {
+	return &WorkerPodAutoscalerList{&wpav1.WorkerPodAutoScalerList{}}
 }
 
 func (s *SecretList) GetItems() (r []runtime.Object) {
@@ -72,6 +81,13 @@ func (s *HorizontalPodAutoscalerList) GetItems() (r []runtime.Object) {
 	return
 }
 
+func (s *WorkerPodAutoscalerList) GetItems() (r []runtime.Object) {
+	for _, i := range s.Item.Items {
+		r = append(r, &i)
+	}
+	return
+}
+
 func (s *SecretList) GetList() (r runtime.Object) {
 	return s.Item
 }
@@ -85,5 +101,9 @@ func (s *ReplicaSetList) GetList() (r runtime.Object) {
 }
 
 func (s *HorizontalPodAutoscalerList) GetList() (r runtime.Object) {
+	return s.Item
+}
+
+func (s *WorkerPodAutoscalerList) GetList() (r runtime.Object) {
 	return s.Item
 }

--- a/pkg/mocks/mutateMatchers.go
+++ b/pkg/mocks/mutateMatchers.go
@@ -66,6 +66,20 @@ func InjectHorizontalPodAutoscalers(hpas []autoscaling.HorizontalPodAutoscaler) 
 	return Callback(fn, "injects horizontalpodautoscalers")
 }
 
+// InjectHorizontalPodAutoscalers puts hpas into a *HorizontalPodAutoscalerList
+func InjectWorkerPodAutoscalers(wpas []wpav1.WorkerPodAutoScaler) gomock.Matcher {
+	fn := func(x interface{}) bool {
+		switch o := x.(type) {
+		case *wpav1.WorkerPodAutoScalerList:
+			o.Items = append(o.Items, wpas...)
+			return true
+		default:
+			return false
+		}
+	}
+	return Callback(fn, "injects workerpodautoscalers")
+}
+
 // InjectPrometheusRules puts PrometheusRules into a *PrometheusRuleList
 func InjectPrometheusRules(rules []monitoringv1.PrometheusRule) gomock.Matcher {
 	fn := func(x interface{}) bool {
@@ -168,4 +182,18 @@ func UpdateWPASpec(wpa *wpav1.WorkerPodAutoScaler) gomock.Matcher {
 		}
 	}
 	return Callback(fn, "update wpa spec")
+}
+
+// UpdateWPAObjectMeta sets the ObjectMeta on a *HorizontalPodAutoscaler
+func UpdateWPAObjectMeta(wpa *wpav1.WorkerPodAutoScaler) gomock.Matcher {
+	fn := func(x interface{}) bool {
+		switch o := x.(type) {
+		case *wpav1.WorkerPodAutoScaler:
+			o.ObjectMeta = wpa.ObjectMeta
+			return true
+		default:
+			return false
+		}
+	}
+	return Callback(fn, "update wpa object meta")
 }


### PR DESCRIPTION
Tested adding and removing revisions of an app configured to scale with a WPA in `sandbox`.

Because WPA's are capable of scaling down a ReplicaSet to 0 and back up, they need to be deleted when retiring a Revision. We may also want to consider using a DeleteRevision plan in place of RetireRevision, as long as we believe we can always rely on Picchu to rollback to an earlier Revision. But for now, this leaves the ReplicaSet and other K8s resources intact in case of disaster recovery.