### PR TITLE
[MED-26863] Ignore NoKindMatchErrors when deleting WPA resources

### DIFF
--- a/pkg/controller/releasemanager/plan/deleteRevision.go
+++ b/pkg/controller/releasemanager/plan/deleteRevision.go
@@ -3,6 +3,8 @@ package plan
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/api/meta"
+
 	picchuv1alpha1 "go.medium.engineering/picchu/pkg/apis/picchu/v1alpha1"
 	"go.medium.engineering/picchu/pkg/controller/utils"
 
@@ -32,8 +34,13 @@ func (p *DeleteRevision) Apply(ctx context.Context, cli client.Client, cluster *
 
 	for _, list := range lists {
 		if err := cli.List(ctx, list.GetList(), opts); err != nil {
-			log.Error(err, "Failed to list resource")
-			return err
+			switch err.(type) {
+			case *meta.NoKindMatchError:
+				continue
+			default:
+				log.Error(err, "Failed to list resource")
+				return err
+			}
 		}
 		log.Info("list", "list", list)
 		for _, item := range list.GetItems() {

--- a/pkg/controller/releasemanager/plan/retireRevision_test.go
+++ b/pkg/controller/releasemanager/plan/retireRevision_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"go.medium.engineering/picchu/pkg/mocks"
 	common "go.medium.engineering/picchu/pkg/plan/test"
 	"go.medium.engineering/picchu/pkg/test"
@@ -28,10 +30,16 @@ func TestRetireMissingRevision(t *testing.T) {
 	ok := client.ObjectKey{Name: "testtag", Namespace: "testnamespace"}
 	ctx := context.TODO()
 
-	wpa := &wpav1.WorkerPodAutoScaler{}
+	wpa := &wpav1.WorkerPodAutoScaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rr.Tag,
+			Namespace: rr.Namespace,
+		},
+	}
+
 	m.
 		EXPECT().
-		Get(ctx, mocks.ObjectKey(ok), mocks.UpdateWPASpec(wpa)).
+		Delete(ctx, mocks.UpdateWPAObjectMeta(wpa)).
 		Return(common.NotFoundError).
 		Times(1)
 
@@ -78,11 +86,6 @@ func TestRetireExistingRevision(t *testing.T) {
 		}
 	}, "ensure Spec.Replicas == 0")
 
-	m.
-		EXPECT().
-		Get(ctx, mocks.ObjectKey(ok), mocks.UpdateWPASpec(wpa)).
-		Return(nil).
-		Times(1)
 	m.
 		EXPECT().
 		Delete(ctx, mocks.UpdateWPASpec(wpa)).


### PR DESCRIPTION
Tested on `sandbox` before and after deleting the WPA CRD