### PR TITLE
Allow concurrent reconciling

### DIFF
--- a/pkg/controller/utils/api.go
+++ b/pkg/controller/utils/api.go
@@ -18,7 +18,7 @@ import (
 )
 
 var cache = map[client.ObjectKey]client.Client{}
-var lock = sync.Mutex{}
+var lock = &sync.Mutex{}
 
 func RemoteClient(ctx context.Context, log logr.Logger, reader client.Reader, cluster *picchuv1alpha1.Cluster) (client.Client, error) {
 	key, err := client.ObjectKeyFromObject(cluster)

--- a/pkg/controller/utils/api.go
+++ b/pkg/controller/utils/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"go.medium.engineering/picchu/pkg/client/scheme"
+	"sync"
 
 	picchuv1alpha1 "go.medium.engineering/picchu/pkg/apis/picchu/v1alpha1"
 
@@ -17,6 +18,7 @@ import (
 )
 
 var cache = map[client.ObjectKey]client.Client{}
+var lock = sync.Mutex{}
 
 func RemoteClient(ctx context.Context, log logr.Logger, reader client.Reader, cluster *picchuv1alpha1.Cluster) (client.Client, error) {
 	key, err := client.ObjectKeyFromObject(cluster)
@@ -44,6 +46,8 @@ func RemoteClient(ctx context.Context, log logr.Logger, reader client.Reader, cl
 	if err != nil {
 		return cli, err
 	}
+	lock.Lock()
+	defer lock.Unlock()
 	cache[key] = cli
 	return cli, nil
 }

--- a/pkg/prometheus/api.go
+++ b/pkg/prometheus/api.go
@@ -57,7 +57,7 @@ type API struct {
 	api   PromAPI
 	cache map[string]cachedValue
 	ttl   time.Duration
-	lock  sync.Mutex
+	lock  *sync.Mutex
 }
 
 type noopAPI struct{}
@@ -74,13 +74,13 @@ func NewAPI(address string, ttl time.Duration) (*API, error) {
 	}
 	if address == "" {
 		log.Info("WARNING: No prometheus address defined, SLOs disabled")
-		return &API{&noopAPI{}, map[string]cachedValue{}, ttl, sync.Mutex{}}, nil
+		return &API{&noopAPI{}, map[string]cachedValue{}, ttl, &sync.Mutex{}}, nil
 	}
-	return &API{api.NewAPI(client), map[string]cachedValue{}, ttl, sync.Mutex{}}, nil
+	return &API{api.NewAPI(client), map[string]cachedValue{}, ttl, &sync.Mutex{}}, nil
 }
 
 func InjectAPI(a PromAPI, ttl time.Duration) *API {
-	return &API{a, map[string]cachedValue{}, ttl, sync.Mutex{}}
+	return &API{a, map[string]cachedValue{}, ttl, &sync.Mutex{}}
 }
 
 func (a API) queryWithCache(ctx context.Context, query string, t time.Time) (model.Value, error) {


### PR DESCRIPTION
Deployed manually, running 50m without crashes