### PR TITLE
Allow app container lifecycle to be configured

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 **/zz_generated.*.go linguist-generated=true
 /pkg/client/** linguist-generated=true
 /pkg/openapi/** linguist-generated=true
+/deploy/crds/** linguist-generated=true
 Gopkg.lock linguist-generated=true

--- a/deploy/crds/picchu.medium.engineering_revisions_crd.yaml
+++ b/deploy/crds/picchu.medium.engineering_revisions_crd.yaml
@@ -1889,6 +1889,195 @@ spec:
                             type: object
                         type: object
                     type: object
+                  lifecycle:
+                    description: Lifecycle describes actions that the management system
+                      should take in response to container lifecycle events. For the
+                      PostStart and PreStop lifecycle handlers, management of the
+                      container blocks until the action is complete, unless the container
+                      process fails, in which case the handler is aborted.
+                    properties:
+                      postStart:
+                        description: 'PostStart is called immediately after a container
+                          is created. If the handler fails, the container is terminated
+                          and restarted according to its restart policy. Other management
+                          of the container blocks until the hook completes. More info:
+                          https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                        properties:
+                          exec:
+                            description: One and only one of the following should
+                              be specified. Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                                description: Name or number of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          tcpSocket:
+                            description: 'TCPSocket specifies an action involving
+                              a TCP port. TCP hooks not yet supported TODO: implement
+                              a realistic TCP lifecycle hook'
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                                description: Number or name of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                            required:
+                            - port
+                            type: object
+                        type: object
+                      preStop:
+                        description: 'PreStop is called immediately before a container
+                          is terminated due to an API request or management event
+                          such as liveness/startup probe failure, preemption, resource
+                          contention, etc. The handler is not called if the container
+                          crashes or exits. The reason for termination is passed to
+                          the handler. The Pod''s termination grace period countdown
+                          begins before the PreStop hooked is executed. Regardless
+                          of the outcome of the handler, the container will eventually
+                          terminate within the Pod''s termination grace period. Other
+                          management of the container blocks until the hook completes
+                          or until the termination grace period is reached. More info:
+                          https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                        properties:
+                          exec:
+                            description: One and only one of the following should
+                              be specified. Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                                description: Name or number of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          tcpSocket:
+                            description: 'TCPSocket specifies an action involving
+                              a TCP port. TCP hooks not yet supported TODO: implement
+                              a realistic TCP lifecycle hook'
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                                description: Number or name of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                            required:
+                            - port
+                            type: object
+                        type: object
+                    type: object
                   livenessProbe:
                     description: Probe describes a health check to be performed against
                       a container to determine whether it is alive or ready to receive

--- a/pkg/apis/picchu/v1alpha1/revision_types.go
+++ b/pkg/apis/picchu/v1alpha1/revision_types.go
@@ -124,6 +124,7 @@ type RevisionTarget struct {
 	Resources      corev1.ResourceRequirements `json:"resources,omitempty"`
 	LivenessProbe  *corev1.Probe               `json:"livenessProbe,omitempty"`
 	ReadinessProbe *corev1.Probe               `json:"readinessProbe,omitempty"`
+	Lifecycle      *corev1.Lifecycle           `json:"lifecycle,omitempty"`
 
 	Affinity    *corev1.Affinity    `json:"affinity,omitempty"`
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`

--- a/pkg/apis/picchu/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/picchu/v1alpha1/zz_generated.deepcopy.go
@@ -1310,6 +1310,11 @@ func (in *RevisionTarget) DeepCopyInto(out *RevisionTarget) {
 		*out = new(corev1.Probe)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Lifecycle != nil {
+		in, out := &in.Lifecycle, &out.Lifecycle
+		*out = new(corev1.Lifecycle)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Affinity != nil {
 		in, out := &in.Affinity, &out.Affinity
 		*out = new(corev1.Affinity)

--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -369,6 +369,7 @@ func (i *Incarnation) sync(ctx context.Context) error {
 		ReadinessProbe:     i.target().ReadinessProbe,
 		LivenessProbe:      i.target().LivenessProbe,
 		MinReadySeconds:    i.target().Scale.MinReadySeconds,
+		Lifecycle:          i.target().Lifecycle,
 		Affinity:           i.target().Affinity,
 		Tolerations:        i.target().Tolerations,
 		EnvVars:            i.target().Env,

--- a/pkg/controller/releasemanager/plan/syncRevision.go
+++ b/pkg/controller/releasemanager/plan/syncRevision.go
@@ -72,6 +72,7 @@ type SyncRevision struct {
 	LivenessProbe      *corev1.Probe
 	ReadinessProbe     *corev1.Probe
 	MinReadySeconds    int32
+	Lifecycle          *corev1.Lifecycle
 	Affinity           *corev1.Affinity
 	Tolerations        []corev1.Toleration
 	EnvVars            []corev1.EnvVar
@@ -94,6 +95,7 @@ func (p *SyncRevision) Printable() interface{} {
 		LivenessProbe      *corev1.Probe
 		ReadinessProbe     *corev1.Probe
 		MinReadySeconds    int32
+		Lifecycle          *corev1.Lifecycle
 		Affinity           *corev1.Affinity
 	}{
 
@@ -111,6 +113,7 @@ func (p *SyncRevision) Printable() interface{} {
 		LivenessProbe:      p.LivenessProbe,
 		ReadinessProbe:     p.ReadinessProbe,
 		MinReadySeconds:    p.MinReadySeconds,
+		Lifecycle:          p.Lifecycle,
 		Affinity:           p.Affinity,
 	}
 }
@@ -190,6 +193,7 @@ func (p *SyncRevision) syncReplicaSet(
 ) error {
 	var livenessProbe *corev1.Probe
 	var readinessProbe *corev1.Probe
+	var lifecycle *corev1.Lifecycle
 	if p.LivenessProbe != nil {
 		probe := *p.LivenessProbe
 		livenessProbe = &probe
@@ -197,6 +201,10 @@ func (p *SyncRevision) syncReplicaSet(
 	if p.ReadinessProbe != nil {
 		probe := *p.ReadinessProbe
 		readinessProbe = &probe
+	}
+	if p.Lifecycle != nil {
+		lc := *p.Lifecycle
+		lifecycle = &lc
 	}
 
 	var ports []corev1.ContainerPort
@@ -225,6 +233,7 @@ func (p *SyncRevision) syncReplicaSet(
 		Resources:      p.Resources,
 		LivenessProbe:  livenessProbe,
 		ReadinessProbe: readinessProbe,
+		Lifecycle:      lifecycle,
 	}
 
 	if hasStatusPort {

--- a/pkg/controller/releasemanager/plan/syncRevision_test.go
+++ b/pkg/controller/releasemanager/plan/syncRevision_test.go
@@ -79,6 +79,13 @@ var (
 				},
 			},
 		}},
+		Lifecycle: &corev1.Lifecycle{
+			PreStop: &corev1.Handler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"/bin/sh", "-c", "sleep 20"},
+				},
+			},
+		},
 		Sidecars: []corev1.Container{
 			{
 				Name:  "test-1",
@@ -212,6 +219,13 @@ var (
 							TimeoutSeconds:      1,
 							SuccessThreshold:    1,
 							FailureThreshold:    3,
+						},
+						Lifecycle: &corev1.Lifecycle{
+							PreStop: &corev1.Handler{
+								Exec: &corev1.ExecAction{
+									Command: []string{"/bin/sh", "-c", "sleep 20"},
+								},
+							},
 						},
 					},
 						{


### PR DESCRIPTION

Allows the application container `lifecycle` to be configured in `RevisionTarget`. 