### PR TITLE
[MED-27107] Allow WPA to manage RS replicas

### DIFF
--- a/pkg/apis/picchu/v1alpha1/common.go
+++ b/pkg/apis/picchu/v1alpha1/common.go
@@ -64,6 +64,7 @@ const (
 	AnnotationFailedAt               = "picchu.medium.engineering/failed-at-timestamp"
 	AnnotationRepo                   = "picchu.medium.engineering/repo"
 	AnnotationCanaryStartedTimestamp = "picchu.medium.engineering/canaryStartedTimestamp"
+	AnnotationAutoscaler             = "picchu.medium.engineering/autoscaler"
 )
 
 type PortInfo struct {

--- a/pkg/apis/picchu/v1alpha1/common.go
+++ b/pkg/apis/picchu/v1alpha1/common.go
@@ -65,6 +65,9 @@ const (
 	AnnotationRepo                   = "picchu.medium.engineering/repo"
 	AnnotationCanaryStartedTimestamp = "picchu.medium.engineering/canaryStartedTimestamp"
 	AnnotationAutoscaler             = "picchu.medium.engineering/autoscaler"
+
+	AutoscalerTypeHPA = "hpa"
+	AutoscalerTypeWPA = "wpa"
 )
 
 type PortInfo struct {

--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -12,11 +12,11 @@ import (
 	rmplan "go.medium.engineering/picchu/pkg/controller/releasemanager/plan"
 	"go.medium.engineering/picchu/pkg/controller/utils"
 	"go.medium.engineering/picchu/pkg/plan"
-	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
 	istiov1alpha3 "istio.io/api/networking/v1alpha3"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -369,6 +369,7 @@ func (i *Incarnation) sync(ctx context.Context) error {
 		ReadinessProbe:     i.target().ReadinessProbe,
 		LivenessProbe:      i.target().LivenessProbe,
 		MinReadySeconds:    i.target().Scale.MinReadySeconds,
+		Worker:             i.target().Scale.Worker,
 		Lifecycle:          i.target().Lifecycle,
 		Affinity:           i.target().Affinity,
 		Tolerations:        i.target().Tolerations,

--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -457,6 +457,8 @@ func (i *Incarnation) genScalePlan(ctx context.Context) *rmplan.ScaleRevision {
 	max := i.divideReplicas(i.target().Scale.Max)
 	if i.status.CurrentPercent == 0 {
 		min = max
+	} else if i.target().Scale.Worker != nil && *i.target().Scale.Min == 0 {
+		min = 0
 	}
 
 	return &rmplan.ScaleRevision{

--- a/pkg/controller/releasemanager/plan/syncRevision.go
+++ b/pkg/controller/releasemanager/plan/syncRevision.go
@@ -298,9 +298,9 @@ func (p *SyncRevision) syncReplicaSet(
 		}
 	}
 
-	autoScaler := "hpa"
+	autoScaler := picchuv1alpha1.AutoscalerTypeHPA
 	if p.Worker != nil {
-		autoScaler = "wpa"
+		autoScaler = picchuv1alpha1.AutoscalerTypeWPA
 	}
 	rsAnnotations := map[string]string{
 		picchuv1alpha1.AnnotationAutoscaler: autoScaler,

--- a/pkg/controller/releasemanager/plan/syncRevision_test.go
+++ b/pkg/controller/releasemanager/plan/syncRevision_test.go
@@ -140,6 +140,9 @@ var (
 			Labels: map[string]string{
 				"test": "label",
 			},
+			Annotations: map[string]string{
+				"picchu.medium.engineering/autoscaler": "hpa",
+			},
 			ResourceVersion: "1",
 		},
 		Spec: appsv1.ReplicaSetSpec{
@@ -280,6 +283,9 @@ var (
 			Namespace: "testnamespace",
 			Labels: map[string]string{
 				"test": "label",
+			},
+			Annotations: map[string]string{
+				"picchu.medium.engineering/autoscaler": "hpa",
 			},
 		},
 		Spec: appsv1.ReplicaSetSpec{

--- a/pkg/plan/common.go
+++ b/pkg/plan/common.go
@@ -341,7 +341,7 @@ func CreateOrUpdate(
 				log.Info("Resource is ignored", "namespace", rs.Namespace, "name", rs.Name, "kind", kind)
 				return nil
 			}
-			if typed.Annotations[picchu.AnnotationAutoscaler] != "wpa" { // Allow WorkerPodAutoScaler to manipulate Replicas on its own
+			if typed.Annotations[picchu.AnnotationAutoscaler] != picchu.AutoscalerTypeWPA { // Allow WorkerPodAutoScaler to manipulate Replicas on its own
 				// Only update replicas if we are changing to/from zero, which means the replicaset is being retired/deployed
 				var zero int32 = 0
 				if rs.Spec.Replicas == nil {


### PR DESCRIPTION
This allows RevisionTarget Scale.Min to be 0 when Scale.Worker is defined.