### PR TITLE
delete wpa when replicas set to 0

### DIFF
--- a/pkg/controller/releasemanager/plan/plan.go
+++ b/pkg/controller/releasemanager/plan/plan.go
@@ -1,0 +1,33 @@
+package plan
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+
+	wpav1 "github.com/practo/k8s-worker-pod-autoscaler/pkg/apis/workerpodautoscaler/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Delete any WorkerPodAutoScaler for the deployed revision
+func deleteWPA(ctx context.Context, cli client.Client, namespace, name string) error {
+	wpa := &wpav1.WorkerPodAutoScaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+	if err := cli.Delete(ctx, wpa); err != nil {
+		switch err.(type) {
+		case *meta.NoKindMatchError:
+			break
+		default:
+			if !errors.IsNotFound(err) {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/controller/releasemanager/plan/syncRevision.go
+++ b/pkg/controller/releasemanager/plan/syncRevision.go
@@ -167,6 +167,16 @@ func (p *SyncRevision) Apply(ctx context.Context, cli client.Client, cluster *pi
 		}
 	}
 
+	if p.Worker != nil && p.Replicas == 0 {
+		if err := deleteWPA(ctx, cli, p.Namespace, p.Tag); err != nil {
+			log.Error(err, "Failed to delete WPA while syncing 0 replica revision",
+				"tag", p.Tag,
+				"name", p.Namespace,
+			)
+			return err
+		}
+	}
+
 	// This is required for DestinationRule mapping, which doesn't allow slashes in label names.
 	labels := map[string]string{
 		"tag.picchu.medium.engineering": p.Tag,
@@ -297,6 +307,7 @@ func (p *SyncRevision) syncReplicaSet(
 			tempSelector[k] = v
 		}
 	}
+	// End badness
 
 	autoScaler := picchuv1alpha1.AutoscalerTypeHPA
 	if p.Worker != nil {
@@ -306,7 +317,6 @@ func (p *SyncRevision) syncReplicaSet(
 		picchuv1alpha1.AnnotationAutoscaler: autoScaler,
 	}
 
-	// End badness
 	replicaSet := &appsv1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   p.Namespace,


### PR DESCRIPTION
This should delete the WPA when a revision is in the `pending release` state.