### PR TITLE
Fix mirroring for Kubernetes 1.17

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -21,6 +21,7 @@ import (
 	"go.medium.engineering/picchu/pkg/client/scheme"
 	"go.medium.engineering/picchu/pkg/webhook"
 	istio "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	apps "k8s.io/api/apps/v1"
 	autoscaling "k8s.io/api/autoscaling/v2beta2"
 	core "k8s.io/api/core/v1"
@@ -117,6 +118,7 @@ func main() {
 		monitoring.AddToScheme,
 		slo.AddToScheme,
 		wpav1.AddToScheme,
+		admissionv1beta1.AddToScheme,
 	}
 
 	for _, sch := range []*k8sruntime.Scheme{mgr.GetScheme(), scheme.Scheme} {

--- a/pkg/controller/releasemanager/plan/syncApp.go
+++ b/pkg/controller/releasemanager/plan/syncApp.go
@@ -69,16 +69,16 @@ func (p *SyncApp) Apply(
 		return err
 	}
 
-	if len(p.DeployedRevisions) == 0 {
-		log.Info("Not syncing app", "Reason", "there are no deployed revisions")
-		return nil
-	}
-
 	sidecarResource := p.sidecarResource()
 	if sidecarResource != nil {
 		if err := plan.CreateOrUpdate(ctx, log, cli, sidecarResource); err != nil {
 			return err
 		}
+	}
+
+	if len(p.DeployedRevisions) == 0 {
+		log.Info("Not syncing app", "Reason", "there are no deployed revisions")
+		return nil
 	}
 
 	destinationRule := p.destinationRule()

--- a/pkg/controller/releasemanager/syncer.go
+++ b/pkg/controller/releasemanager/syncer.go
@@ -190,15 +190,16 @@ func (r *ResourceSyncer) observe(ctx context.Context) error {
 func (r *ResourceSyncer) syncApp(ctx context.Context) error {
 	portMap := map[string]picchuv1alpha1.PortInfo{}
 	incarnations := r.incarnations.deployed()
-	if len(incarnations) < 1 {
-		return nil
-	}
 
 	// Include ports from apps in "deploying" state
 	for _, incarnation := range r.incarnations.sorted() {
 		if incarnation.status.State.Current == "deploying" {
 			incarnations = append(incarnations, incarnation)
 		}
+	}
+
+	if len(incarnations) < 1 {
+		return nil
 	}
 
 	for _, incarnation := range incarnations {

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"go.medium.engineering/picchu/pkg/webhook/revision"
-	admissionregistration "k8s.io/api/admissionregistration/v1"
+	admissionregistration "k8s.io/api/admissionregistration/v1beta1"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION

Explicitly supports only the `v1beta1` admission schema.