### PR TITLE
Migrate nodeSelector during mirroring

### DIFF
--- a/pkg/controller/revision/revision_controller.go
+++ b/pkg/controller/revision/revision_controller.go
@@ -523,6 +523,20 @@ func (r *ReconcileRevision) mirrorRevision(
 	}
 	for i := range revCopy.Spec.Targets {
 		revCopy.Spec.Targets[i].ExternalTest.Enabled = false
+
+		// temp hack to migrate node affinity labels to Kubernetes 1.16+ ("node-role.kubernetes.io" is no longer allowed)
+		if revCopy.Spec.Targets[i].Affinity != nil &&
+			revCopy.Spec.Targets[i].Affinity.NodeAffinity != nil &&
+			revCopy.Spec.Targets[i].Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil &&
+			len(revCopy.Spec.Targets[i].Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms) == 1 &&
+			len(revCopy.Spec.Targets[i].Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchFields) == 1 {
+
+			if revCopy.Spec.Targets[i].Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchFields[0].Key == "node-role.kubernetes.io/infrastructure" {
+				revCopy.Spec.Targets[i].Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchFields[0].Key = "node.medium.engineering/role"
+				revCopy.Spec.Targets[i].Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchFields[0].Values = []string{"infrastructure"}
+				revCopy.Spec.Targets[i].Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchFields[0].Operator = corev1.NodeSelectorOpIn
+			}
+		}
 	}
 	log.Info("Syncing revision", "revision", revCopy)
 	_, err = controllerutil.CreateOrUpdate(ctx, remoteClient, revCopy, func() error {


### PR DESCRIPTION

We have an issue right now when mirroring Revisions from a Kubernetes 1.15 to a 1.16+ cluster. We can no longer use `node-role.kubernetes.io` for `NodeAffinity` configuration, we need to use `node.medium.engineering/role`.

This PR will be merged to main and deployed to the existing cluster. It can be reverted once our migration is complete.