### PR TITLE
Only fail tests on test failures

### DIFF
--- a/pkg/controller/releasemanager/state.go
+++ b/pkg/controller/releasemanager/state.go
@@ -234,7 +234,8 @@ func Testing(ctx context.Context, deployment Deployment) (State, error) {
 	if !deployment.hasRevision() {
 		return deleting, nil
 	}
-	if HasFailed(deployment) {
+	// Only transition to failure on external test failures, ignoring all other failure states.
+	if deployment.getExternalTestStatus() == ExternalTestFailed {
 		return failing, nil
 	}
 	externalTestStatus := deployment.getExternalTestStatus()

--- a/pkg/controller/releasemanager/state_test.go
+++ b/pkg/controller/releasemanager/state_test.go
@@ -228,9 +228,9 @@ func TestTesting(t *tt.T) {
 	testcase(tested, m(true, false, ExternalTestSucceeded))
 	testcase(failing, m(true, false, ExternalTestFailed))
 
-	testcase(failing, m(true, true, ExternalTestPending))
-	testcase(failing, m(true, true, ExternalTestStarted))
-	testcase(failing, m(true, true, ExternalTestSucceeded))
+	testcase(pendingtest, m(true, true, ExternalTestPending))
+	testcase(testing, expectSync(m(true, true, ExternalTestStarted)))
+	testcase(tested, m(true, true, ExternalTestSucceeded))
 	testcase(failing, m(true, true, ExternalTestFailed))
 
 	m = func(hasRevision, markedAsFailed bool, externalTestStatus ExternalTestStatus) *MockDeployment {


### PR DESCRIPTION
This allows us to know that the revision entered failed state on signal from hermit and not something else.