### PR TITLE
GC failed and timedout revisions

### DIFF
--- a/deploy/crds/picchu.medium.engineering_revisions_crd.yaml
+++ b/deploy/crds/picchu.medium.engineering_revisions_crd.yaml
@@ -4186,6 +4186,8 @@ spec:
                     - desired
                     - peak
                     type: object
+                  state:
+                    type: string
                 required:
                 - name
                 - release

--- a/pkg/apis/picchu/v1alpha1/revision_types.go
+++ b/pkg/apis/picchu/v1alpha1/revision_types.go
@@ -10,15 +10,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Reference imports to suppress errors if they are not otherwise used.
-
-var (
-	// TODO(bob): I don't like this. maybe configurable?
-	// Which targets need to reach 100% to consider the rollout complete and
-	// stop slo failures from rolling back.
-	rolloutTargets = []string{"production"}
-)
-
 // see custom_deepcopy.go
 // +k8s:deepcopy-gen=false
 type Istio struct {
@@ -214,6 +205,7 @@ type RevisionTargetStatus struct {
 	Name    string                `json:"name"`
 	Scale   RevisionScaleStatus   `json:"scale"`
 	Release RevisionReleaseStatus `json:"release"`
+	State   string                `json:"state,omitempty"`
 }
 
 type RevisionScaleStatus struct {
@@ -233,6 +225,7 @@ func (r *RevisionTargetStatus) AddReleaseManagerStatus(status ReleaseManagerRevi
 	r.Scale.Current = uint32(status.Scale.Current)
 	r.Scale.Desired = uint32(status.Scale.Desired)
 	r.Scale.Peak = uint32(status.Scale.Peak)
+	r.State = status.State.Current
 }
 
 func (r *Revision) GitTimestamp() time.Time {

--- a/pkg/apis/picchu/v1alpha1/source_defaults.go
+++ b/pkg/apis/picchu/v1alpha1/source_defaults.go
@@ -1,9 +1,10 @@
 package v1alpha1
 
 import (
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
 )
 
 const (
@@ -23,6 +24,8 @@ const (
 	defaultPortPort          = int32(80)
 	defaultPortProtocol      = corev1.ProtocolTCP
 	defaultPortMode          = PortPrivate
+
+	defaultExternalTestTimeout = time.Duration(2) * time.Hour
 )
 
 var (
@@ -44,6 +47,13 @@ func SetDefaults_RevisionSpec(spec *RevisionSpec) {
 		for j := range spec.Targets[i].Ports {
 			SetPortDefaults(&spec.Targets[i].Ports[j])
 		}
+		SetExternalTestDefaults(&spec.Targets[i].ExternalTest)
+	}
+}
+
+func SetExternalTestDefaults(externalTest *ExternalTest) {
+	if externalTest.Timeout == nil {
+		externalTest.Timeout = &metav1.Duration{Duration: defaultExternalTestTimeout}
 	}
 }
 

--- a/pkg/controller/releasemanager/garbagecollector/defaultStrategy.go
+++ b/pkg/controller/releasemanager/garbagecollector/defaultStrategy.go
@@ -6,6 +6,8 @@ import (
 	"github.com/go-logr/logr"
 )
 
+const FailedTTL = time.Duration(8) * time.Hour
+
 func defaultStrategy(log logr.Logger, revisions []Revision) ([]Revision, error) {
 	budget := MinimumRetired
 	toDelete := []Revision{}
@@ -15,6 +17,12 @@ func defaultStrategy(log logr.Logger, revisions []Revision) ([]Revision, error) 
 		if rev.State() == "retired" && budget > 0 {
 			budget--
 			continue
+		}
+		if rev.State() == "failed" {
+			if time.Now().After(rev.CreatedOn().Add(FailedTTL)) {
+				toDelete = append(toDelete, rev)
+				continue
+			}
 		}
 		if time.Now().After(rev.CreatedOn().Add(rev.TTL())) {
 			switch rev.State() {

--- a/pkg/controller/releasemanager/state_test.go
+++ b/pkg/controller/releasemanager/state_test.go
@@ -644,6 +644,28 @@ func TestFailed(t *tt.T) {
 	testcase(failed, expectRetire(m(true, false, ExternalTestFailed)))
 }
 
+func TestTimingout(t *tt.T) {
+	ctrl := gomock.NewController(t)
+	ctx := context.TODO()
+	defer ctrl.Finish()
+
+	m := func(hasRevision, markedAsFailed bool, externalTestStatus ExternalTestStatus) *MockDeployment {
+		return createMockDeployment(ctrl, responses{
+			hasRevision:        hasRevision,
+			markedAsFailed:     markedAsFailed,
+			externalTestStatus: externalTestStatus,
+		})
+	}
+
+	testcase := func(expected State, mock *MockDeployment) {
+		testHandler(ctx, t, "timingout", expected, mock)
+	}
+
+	testcase(failing, m(true, true, ExternalTestSucceeded))
+	testcase(failing, m(true, false, ExternalTestFailed))
+	testcase(timingout, m(true, false, ExternalTestPending))
+}
+
 func testHandler(ctx context.Context, t *tt.T, handler string, expected State, m *MockDeployment) {
 	state, err := handlers[handler](ctx, m)
 	assert.NoError(t, err)

--- a/pkg/controller/revision/revision_controller_test.go
+++ b/pkg/controller/revision/revision_controller_test.go
@@ -1,0 +1,130 @@
+package revision
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/prometheus/common/model"
+
+	"github.com/golang/mock/gomock"
+	"go.medium.engineering/picchu/pkg/prometheus"
+	"go.medium.engineering/picchu/pkg/prometheus/mocks"
+
+	testify "github.com/stretchr/testify/assert"
+	picchu "go.medium.engineering/picchu/pkg/apis/picchu/v1alpha1"
+	"go.medium.engineering/picchu/pkg/controller/utils"
+	"go.medium.engineering/picchu/pkg/test"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestReconcileRevision_Reconcile(t *testing.T) {
+	log := test.MustNewLogger()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(2)*time.Minute)
+	defer cancel()
+	scheme := runtime.NewScheme()
+	picchu.AddToScheme(scheme)
+	picchu.RegisterDefaults(scheme)
+	ctrl := gomock.NewController(t)
+	m := mocks.NewMockPromAPI(ctrl)
+	m.EXPECT().Query(gomock.Any(), gomock.Any(), gomock.Any()).Return(model.Vector{}, nil, nil).AnyTimes()
+
+	for _, test := range []struct {
+		state    string
+		expected bool
+	}{
+		{
+			state:    "deployed",
+			expected: false,
+		},
+		{
+			state:    "deploying",
+			expected: false,
+		},
+		{
+			state:    "releasing",
+			expected: false,
+		},
+		{
+			state:    "released",
+			expected: false,
+		},
+		{
+			state:    "timingout",
+			expected: true,
+		},
+	} {
+		t.Run(test.state, func(t *testing.T) {
+			assert := testify.New(t)
+			fixtures := []runtime.Object{
+				&picchu.Revision{
+					ObjectMeta: meta.ObjectMeta{
+						Name:      "rev",
+						Namespace: "picchu",
+						Labels: map[string]string{
+							"label": "value",
+						},
+					},
+					Spec: picchu.RevisionSpec{
+						App: picchu.RevisionApp{
+							Name:  "app",
+							Ref:   "ref",
+							Tag:   "v1",
+							Image: "image",
+						},
+						Targets: []picchu.RevisionTarget{
+							{
+								Name:  "target",
+								Fleet: "fleet",
+							},
+						},
+					},
+				},
+				&picchu.ReleaseManager{
+					ObjectMeta: meta.ObjectMeta{
+						Name:      "app-target",
+						Namespace: "picchu",
+						Labels: map[string]string{
+							picchu.LabelTarget: "target",
+							picchu.LabelFleet:  "fleet",
+							picchu.LabelApp:    "app",
+						},
+					},
+					Status: picchu.ReleaseManagerStatus{
+						Revisions: []picchu.ReleaseManagerRevisionStatus{
+							{
+								Tag: "v1",
+								State: picchu.ReleaseManagerRevisionStateStatus{
+									Current: test.state,
+									Target:  test.state,
+								},
+							},
+						},
+					},
+				},
+			}
+			cli := fake.NewFakeClientWithScheme(scheme, fixtures...)
+			reconciler := ReconcileRevision{
+				client:       cli,
+				scheme:       scheme,
+				config:       utils.Config{},
+				promAPI:      prometheus.InjectAPI(m, time.Duration(1)*time.Second),
+				customLogger: log,
+			}
+			key, err := client.ObjectKeyFromObject(fixtures[0])
+			assert.NoError(err)
+			res, err := reconciler.Reconcile(reconcile.Request{NamespacedName: key})
+			assert.NoError(err)
+			assert.NotNil(res)
+
+			instance := &picchu.Revision{}
+			assert.NoError(cli.Get(ctx, key, instance))
+			assert.Equal(test.expected, instance.Spec.Failed)
+		})
+	}
+}


### PR DESCRIPTION
Delete failed and timedout revisions right away. This should make redeploying easier too!