### PR TITLE
Prefer ScalingFactorString for ClusterSpec

### DIFF
--- a/pkg/apis/picchu/v1alpha1/source_defaults.go
+++ b/pkg/apis/picchu/v1alpha1/source_defaults.go
@@ -38,6 +38,10 @@ func SetDefaults_ClusterSpec(spec *ClusterSpec) {
 		one := float64(1.0)
 		spec.ScalingFactor = &one
 	}
+	if spec.ScalingFactorString == nil {
+		one := "1.0"
+		spec.ScalingFactorString = &one
+	}
 }
 
 func SetDefaults_RevisionSpec(spec *RevisionSpec) {

--- a/pkg/controller/releasemanager/plan/init_test.go
+++ b/pkg/controller/releasemanager/plan/init_test.go
@@ -23,16 +23,16 @@ import (
 )
 
 var (
-	scalingFactor = 1.0
+	scalingFactor = "1.0"
 	cluster       = &picchu.Cluster{
 		Spec: picchu.ClusterSpec{
-			ScalingFactor: &scalingFactor,
+			ScalingFactorString: &scalingFactor,
 		},
 	}
-	halfScalingFactor = 0.5
+	halfScalingFactor = "0.5"
 	halfCluster       = &picchu.Cluster{
 		Spec: picchu.ClusterSpec{
-			ScalingFactor: &halfScalingFactor,
+			ScalingFactorString: &halfScalingFactor,
 		},
 	}
 	scheme     = runtime.NewScheme()

--- a/pkg/controller/releasemanager/plan/syncApp_test.go
+++ b/pkg/controller/releasemanager/plan/syncApp_test.go
@@ -378,13 +378,13 @@ func TestSyncNewApp(t *testing.T) {
 		defaultExpectedIstioSidecar,
 	}
 
-	scalingFactor := 0.5
+	scalingFactor := "0.5"
 	cluster := &picchuv1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-a",
 		},
 		Spec: picchuv1alpha1.ClusterSpec{
-			ScalingFactor: &scalingFactor,
+			ScalingFactorString: &scalingFactor,
 			Ingresses: picchuv1alpha1.ClusterIngresses{
 				Public: picchuv1alpha1.IngressInfo{
 					Gateway: "public-gateway",
@@ -408,13 +408,13 @@ func TestDomains(t *testing.T) {
 	ctx := context.TODO()
 	log := test.MustNewLogger()
 	cli := fakeClient()
-	scalingFactor := 1.0
+	scalingFactor := "1.0"
 	cluster := &picchuv1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-a",
 		},
 		Spec: picchuv1alpha1.ClusterSpec{
-			ScalingFactor: &scalingFactor,
+			ScalingFactorString: &scalingFactor,
 			Ingresses: picchuv1alpha1.ClusterIngresses{
 				Public: picchuv1alpha1.IngressInfo{
 					Gateway:        "public-ingressgateway",
@@ -512,13 +512,13 @@ func TestHosts(t *testing.T) {
 		Hosts: []string{"www.dkpn.io"},
 		Mode:  picchuv1alpha1.PortPrivate,
 	}
-	scalingFactor := 1.0
+	scalingFactor := "1.0"
 	cluster := &picchuv1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-a",
 		},
 		Spec: picchuv1alpha1.ClusterSpec{
-			ScalingFactor: &scalingFactor,
+			ScalingFactorString: &scalingFactor,
 			Ingresses: picchuv1alpha1.ClusterIngresses{
 				Public: picchuv1alpha1.IngressInfo{
 					Gateway:        "public-ingressgateway",
@@ -564,13 +564,13 @@ func TestHosts(t *testing.T) {
 
 func TestHostsWithVariantsEnabled(t *testing.T) {
 	assert := testify.New(t)
-	scalingFactor := 0.5
+	scalingFactor := "0.5"
 	cluster := &picchuv1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-a",
 		},
 		Spec: picchuv1alpha1.ClusterSpec{
-			ScalingFactor: &scalingFactor,
+			ScalingFactorString: &scalingFactor,
 			Ingresses: picchuv1alpha1.ClusterIngresses{
 				Public: picchuv1alpha1.IngressInfo{
 					Gateway: "public-gateway",
@@ -829,7 +829,7 @@ func TestHostsWithVariantsEnabled(t *testing.T) {
 
 func TestProductionEcho(t *testing.T) {
 	assert := testify.New(t)
-	scalingFactor := 1.0
+	scalingFactor := "1.0"
 	cluster := &picchuv1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "production-reef-a",
@@ -839,8 +839,8 @@ func TestProductionEcho(t *testing.T) {
 			},
 		},
 		Spec: picchuv1alpha1.ClusterSpec{
-			Enabled:       true,
-			ScalingFactor: &scalingFactor,
+			Enabled:             true,
+			ScalingFactorString: &scalingFactor,
 			Ingresses: picchuv1alpha1.ClusterIngresses{
 				Public: picchuv1alpha1.IngressInfo{
 					Gateway: "public-ingressgateway.istio-system.svc.cluster.local",
@@ -1117,7 +1117,7 @@ func TestProductionEcho(t *testing.T) {
 
 func TestDevRoutes(t *testing.T) {
 	assert := testify.New(t)
-	scalingFactor := 1.0
+	scalingFactor := "1.0"
 	cluster := &picchuv1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "staging-reef-a",
@@ -1130,7 +1130,7 @@ func TestDevRoutes(t *testing.T) {
 			Enabled:             true,
 			EnableDevRoutes:     true,               // what this function is testing
 			DevRouteTagTemplate: "dev-{{.App}}-tag", // what this function is testing
-			ScalingFactor:       &scalingFactor,
+			ScalingFactorString: &scalingFactor,
 			Ingresses: picchuv1alpha1.ClusterIngresses{
 				Public: picchuv1alpha1.IngressInfo{
 					Gateway: "public-ingressgateway.istio-system.svc.cluster.local",

--- a/pkg/controller/releasemanager/plan/syncRevision.go
+++ b/pkg/controller/releasemanager/plan/syncRevision.go
@@ -176,6 +176,14 @@ func (p *SyncRevision) Apply(ctx context.Context, cli client.Client, cluster *pi
 	}
 
 	scalingFactor := cluster.Spec.ScalingFactor
+	if cluster.Spec.ScalingFactorString != nil {
+		f, err := strconv.ParseFloat(*cluster.Spec.ScalingFactorString, 64)
+		if err != nil {
+			log.Error(err, "Could not parse %v to float", *cluster.Spec.ScalingFactorString)
+		} else {
+			scalingFactor = &f
+		}
+	}
 	if scalingFactor == nil {
 		e := fmt.Errorf("cluster scalingFactor is nil")
 		log.Error(e, "Failed to sync revision")

--- a/pkg/plan/composite_test.go
+++ b/pkg/plan/composite_test.go
@@ -15,10 +15,10 @@ import (
 )
 
 var (
-	scalingFactor = 1.0
+	scalingFactor = "1.0"
 	cluster       = &picchuv1alpha1.Cluster{
 		Spec: picchuv1alpha1.ClusterSpec{
-			ScalingFactor: &scalingFactor,
+			ScalingFactorString: &scalingFactor,
 		},
 	}
 )


### PR DESCRIPTION

<details>
<summary>REVIEWERS (7)</summary>

R=@dokipen
R=@ddbenson
R=@eduardoramirez
R=@jeanchung
R=@joshfrench
R=@kvnxush
R=@ssinha31
</details>

Preparing to remove the `scalingFactor` float64.