### PR TITLE
Don't use separate TTL when garbage collecting failed revisions

### DIFF
--- a/pkg/controller/releasemanager/garbagecollector/defaultStrategy.go
+++ b/pkg/controller/releasemanager/garbagecollector/defaultStrategy.go
@@ -6,8 +6,6 @@ import (
 	"github.com/go-logr/logr"
 )
 
-const FailedTTL = time.Duration(8) * time.Hour
-
 func defaultStrategy(log logr.Logger, revisions []Revision) ([]Revision, error) {
 	budget := MinimumRetired
 	toDelete := []Revision{}
@@ -17,12 +15,6 @@ func defaultStrategy(log logr.Logger, revisions []Revision) ([]Revision, error) 
 		if rev.State() == "retired" && budget > 0 {
 			budget--
 			continue
-		}
-		if rev.State() == "failed" {
-			if time.Now().After(rev.CreatedOn().Add(FailedTTL)) {
-				toDelete = append(toDelete, rev)
-				continue
-			}
 		}
 		if time.Now().After(rev.CreatedOn().Add(rev.TTL())) {
 			switch rev.State() {

--- a/pkg/controller/releasemanager/garbagecollector/defaultStrategy_test.go
+++ b/pkg/controller/releasemanager/garbagecollector/defaultStrategy_test.go
@@ -127,6 +127,36 @@ func TestDefaultStrategyNotEnoughExpired(t *testing.T) {
 	assert.Equal(t, 2011, sortedOut[4].CreatedOn().Year(), "correct revisions found")
 }
 
+func TestDefaultStrategyFailedTTL(t *testing.T) {
+	in := []Revision{
+		&testRevision{
+			ttl:       1 * time.Hour,
+			createdOn: time.Now().Add(time.Hour * -1),
+			state:     "failed",
+		},
+		&testRevision{
+			ttl:       1 * time.Hour,
+			createdOn: time.Now(),
+			state:     "failed",
+		},
+		&testRevision{
+			ttl:       1 * time.Hour,
+			createdOn: time.Now(),
+			state:     "retired",
+		},
+		&testRevision{
+			ttl:       1 * time.Hour,
+			createdOn: time.Now(),
+			state:     "deployed",
+		},
+	}
+	out, err := FindGarbage(nil, DefaultStrategy, in)
+	assert.NoError(t, err, "error during find garbage")
+	assert.Equal(t, 1, len(out), "correct number of revisions found")
+	sortedOut := sortRevisions(out)
+	assert.Equal(t, "failed", sortedOut[0].State(), "correct revisions found")
+}
+
 func TestDefaultStrategyDontDeleteAll(t *testing.T) {
 	for _, test := range []struct {
 		Name             string


### PR DESCRIPTION
<details>
<summary>REVIEWERS (7)</summary>

R=@dokipen
R=@ddbenson
R=@eduardoramirez
R=@jeanchung
R=@joshfrench
R=@kvnxush
R=@ssinha31
</details>

This PR changes the garbage collection strategy for `failed` revisions to be cleaned up after the Revision's release TTL has expired, instead of a special 8 hour TTL. This should prevent failed revisions from unexpectedly disappearing from the revisions list after only 8 hours.

We set the [default GC TTL to be 5 days](https://github.com/Medium/picchu/blob/main/pkg/apis/picchu/v1alpha1/source_defaults.go#L13), so `failed` revisions will get cleaned up after 5 days like everything else.