### PR TITLE
removed info logging that was not very useful to report to datadog

### DIFF
--- a/pkg/controller/cluster/cluster_controller.go
+++ b/pkg/controller/cluster/cluster_controller.go
@@ -67,7 +67,6 @@ type ReconcileCluster struct {
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileCluster) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reqLogger.Info("Reconciling Cluster")
 
 	// Fetch the Cluster instance
 	instance := &picchuv1alpha1.Cluster{}

--- a/pkg/controller/clustersecrets/clustersecrets_controller.go
+++ b/pkg/controller/clustersecrets/clustersecrets_controller.go
@@ -70,7 +70,6 @@ type ReconcileClusterSecrets struct {
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileClusterSecrets) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reqLogger.Info("Reconciling ClusterSecrets")
 	ctx := context.TODO()
 
 	// Fetch the ClusterSecrets instance

--- a/pkg/controller/releasemanager/incarnation.go
+++ b/pkg/controller/releasemanager/incarnation.go
@@ -866,7 +866,6 @@ func newIncarnationCollection(controller Controller, revisionList *picchuv1alpha
 		inc := sorted[i]
 		state := State(inc.status.State.Current)
 		if state != canaried && state != canarying {
-			controller.getLog().Info("Setting revision as ramping", "tag", inc.tag)
 			inc.isRamping = true
 			break
 		}

--- a/pkg/controller/releasemanager/incarnation_controller.go
+++ b/pkg/controller/releasemanager/incarnation_controller.go
@@ -108,12 +108,10 @@ func (i *IncarnationController) getConfigMaps(ctx context.Context, opts *client.
 }
 
 func (i *IncarnationController) applyPlan(ctx context.Context, name string, p plan.Plan) error {
-	i.log.Info("Applying plan", "Name", name, "Plan", p)
 	return i.planApplier.Apply(ctx, p)
 }
 
 func (i *IncarnationController) applyDeliveryPlan(ctx context.Context, name string, p plan.Plan) error {
-	i.log.Info("Applying delivery plan", "Name", name, "Plan", p)
 	return i.deliveryApplier.Apply(ctx, p)
 }
 

--- a/pkg/controller/releasemanager/observe/observer.go
+++ b/pkg/controller/releasemanager/observe/observer.go
@@ -54,7 +54,6 @@ func (o *ClusterObserver) Observe(ctx context.Context, namespace string) (*Obser
 	obs := &Observation{
 		ReplicaSets: replicaSets,
 	}
-	o.log.Info("Cluster state", "Observation", obs)
 	return obs, nil
 }
 

--- a/pkg/controller/releasemanager/plan/deleteRevision.go
+++ b/pkg/controller/releasemanager/plan/deleteRevision.go
@@ -42,7 +42,6 @@ func (p *DeleteRevision) Apply(ctx context.Context, cli client.Client, cluster *
 				return err
 			}
 		}
-		log.Info("list", "list", list)
 		for _, item := range list.GetItems() {
 			kind := utils.MustGetKind(item)
 			log.Info("Deleting remote resource",

--- a/pkg/controller/releasemanager/state.go
+++ b/pkg/controller/releasemanager/state.go
@@ -159,12 +159,7 @@ func (s *DeploymentStateManager) tick(ctx context.Context) error {
 		return err
 	}
 	s.deployment.setState(string(nextState))
-	s.deployment.getLog().Info(
-		"Advanced state",
-		"current", string(nextState),
-		"previous", currentState,
-		"stateChanged", string(nextState) != currentState,
-	)
+
 	return nil
 }
 

--- a/pkg/controller/releasemanager/syncer.go
+++ b/pkg/controller/releasemanager/syncer.go
@@ -117,12 +117,10 @@ func (r *ResourceSyncer) del(ctx context.Context) error {
 }
 
 func (r *ResourceSyncer) applyPlan(ctx context.Context, name string, p plan.Plan) error {
-	r.log.Info("Applying plan", "Name", name, "Plan", p)
 	return r.planApplier.Apply(ctx, p)
 }
 
 func (r *ResourceSyncer) applyDeliveryPlan(ctx context.Context, name string, p plan.Plan) error {
-	r.log.Info("Applying delivery plan", "Name", name, "Plan", p)
 	return r.deliveryApplier.Apply(ctx, p)
 }
 
@@ -154,7 +152,6 @@ func (r *ResourceSyncer) reportMetrics() error {
 			lastUpdated = &incarnation.status.State.LastUpdated.Time
 			age = time.Since(*lastUpdated).Seconds()
 		}
-		r.log.Info("Computing state age", "lastUpdated", lastUpdated, "state", current, "age", age)
 		if oldest, ok := oldestIncarnationsInState[current]; !ok || oldest < age {
 			oldestIncarnationsInState[current] = age
 		}
@@ -179,8 +176,6 @@ func (r *ResourceSyncer) reportMetrics() error {
 }
 
 func (r *ResourceSyncer) tickIncarnations(ctx context.Context) error {
-	r.log.Info("Incarnation count", "count", len(r.incarnations.sorted()))
-
 	for _, incarnation := range r.incarnations.sorted() {
 		var lastUpdated *time.Time
 		if incarnation.status.State.LastUpdated != nil {
@@ -473,12 +468,6 @@ func (r *ResourceSyncer) prepareRevisions() []rmplan.Revision {
 		oldCurrentPercent := status.CurrentPercent
 
 		if firstNonCanary == -1 && incarnation.isRamping {
-			r.log.Info(
-				"Found first ramping release",
-				"firstNonCanary", i,
-				"Tag", incarnation.tag,
-				"currentState", status.State.Current,
-			)
 			firstNonCanary = i
 			firstNonCanaryTag = incarnation.tag
 		}
@@ -499,16 +488,6 @@ func (r *ResourceSyncer) prepareRevisions() []rmplan.Revision {
 			panic("Assertion failed")
 		}
 		incarnation.updateCurrentPercent(currentPercent)
-		r.log.Info(
-			"Updated incarnation CurrentPercent",
-			"Tag", incarnation.tag,
-			"oldCurrentPercent", oldCurrentPercent,
-			"currentPercent", currentPercent,
-			"weightChanged", currentPercent != oldCurrentPercent,
-			"desiredReplicas", status.Scale.Desired,
-			"currentReplicas", status.Scale.Current,
-			"currentState", status.State.Current,
-		)
 
 		percRemaining -= currentPercent
 

--- a/pkg/controller/revision/revision_controller.go
+++ b/pkg/controller/revision/revision_controller.go
@@ -130,7 +130,6 @@ func (r *ReconcileRevision) Reconcile(request reconcile.Request) (reconcile.Resu
 	if r.customLogger != nil {
 		reqLogger = r.customLogger
 	}
-	reqLogger.Info("Reconciling Revision")
 
 	// Fetch the Revision instance
 	ctx := context.TODO()
@@ -196,12 +195,6 @@ func (r *ReconcileRevision) Reconcile(request reconcile.Request) (reconcile.Resu
 				}
 				mirrorFailureCounter.With(mLabels).Inc()
 			}
-		}
-	} else {
-		if instance.Spec.DisableMirroring {
-			log.Info("Mirroring disabled")
-		} else {
-			log.Info("Skipping mirroring because revision isn't deployed to any target")
 		}
 	}
 
@@ -284,7 +277,6 @@ func (r *ReconcileRevision) Requeue(log logr.Logger, err error) (reconcile.Resul
 		log.Error(err, "Reconcile resulted in error")
 		return reconcile.Result{}, err
 	}
-	log.Info("Reconciled successfully", "requeue", true, "requeueAfter", r.config.RequeueAfter)
 	return reconcile.Result{RequeueAfter: r.config.RequeueAfter}, nil
 }
 
@@ -293,7 +285,6 @@ func (r *ReconcileRevision) NoRequeue(log logr.Logger, err error) (reconcile.Res
 		log.Error(err, "Reconcile resulted in error")
 		return reconcile.Result{}, err
 	}
-	log.Info("Reconciled successfully", "requeue", false)
 	return reconcile.Result{}, nil
 }
 

--- a/pkg/controller/utils/api.go
+++ b/pkg/controller/utils/api.go
@@ -39,7 +39,6 @@ func RemoteClient(ctx context.Context, log logr.Logger, reader client.Reader, cl
 	if client, ok := checkCache(key); ok {
 		return client, nil
 	}
-	log.Info("Initializing remote client", "Cluster", cluster.Name)
 	secret := &corev1.Secret{}
 	if err = reader.Get(ctx, key, secret); err != nil {
 		return nil, err

--- a/pkg/plan/common.go
+++ b/pkg/plan/common.go
@@ -34,25 +34,21 @@ func LogSync(log logr.Logger, op controllerutil.OperationResult, err error, reso
 			log.Error(err, "Sync resource", "Result", "failure", "Kind", kind, "Audit", true, "Resource", obj.Spec, "Op", op)
 			return
 		}
-		log.Info("Sync resource", "Result", "success", "Kind", kind, "Audit", true, "Resource", obj.Spec, "Op", op)
 	case *corev1.Service:
 		if err != nil {
 			log.Error(err, "Sync resource", "Result", "failure", "Kind", kind, "Audit", true, "Resource", obj.Spec, "Op", op)
 			return
 		}
-		log.Info("Sync resource", "Result", "success", "Kind", kind, "Audit", true, "Resource", obj.Spec, "Op", op)
 	case *appsv1.ReplicaSet:
 		if err != nil {
 			log.Error(err, "Sync resource", "Result", "failure", "Kind", kind, "Audit", true, "Resource", obj.Spec, "Op", op)
 			return
 		}
-		log.Info("Sync resource", "Result", "success", "Kind", kind, "Audit", true, "Resource", obj.Spec, "Op", op)
 	default:
 		if err != nil {
 			log.Error(err, "Sync resource", "Result", "failure", "Kind", kind, "Audit", true, "Resource", resource, "Op", op)
 			return
 		}
-		log.Info("Sync resource", "Result", "success", "Kind", kind, "Audit", true, "Resource", resource, "Op", op)
 	}
 }
 

--- a/pkg/plan/composite.go
+++ b/pkg/plan/composite.go
@@ -2,8 +2,9 @@ package plan
 
 import (
 	"context"
-	picchuv1alpha1 "go.medium.engineering/picchu/pkg/apis/picchu/v1alpha1"
 	"reflect"
+
+	picchuv1alpha1 "go.medium.engineering/picchu/pkg/apis/picchu/v1alpha1"
 
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,12 +31,6 @@ func (p *compositePlan) Apply(ctx context.Context, cli client.Client, cluster *p
 		plan := p.plans[i]
 		planType := reflect.TypeOf(plan).Elem()
 
-		switch v := plan.(type) {
-		case PrintablePlan:
-			log.Info("Applying Plan", "Plan", v.Printable())
-		default:
-			log.Info("Applying Plan", "Plan", plan)
-		}
 		if err := plan.Apply(ctx, cli, cluster, log.WithValues("Applier", planType.Name())); err != nil {
 			return err
 		}


### PR DESCRIPTION
picchu reports a lot of logs to datadog that are mostly debug-level logs that are not useful to us when looking at problems. There are logs in picchu that do log errors as they happen, which are the more useful ones to have. Especially at this distributed scale, without the context within which these operations are happening, the logs are even less useful and just get in the way.

I would have bumped them down to a `debug` level, but the logging framework that picchu uses only supports `Info` and `Error` level logging for now.

These `Info` logs contribute the vast majority of our datadog logs, at 76 MILLION log events per day, with jubilee in second place at only 15 Million log events per day. Over the course of a month, this should save us 2.2 billion logging events. Not sure how much of a savings this translates to, but if we pay per log, with a daily average of 178M log events, and this PR removes about 70M, this should lead to a 40% reduction in our bill.