### PR TITLE
Update rbac config so that leases are included in permissions

### DIFF
--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: leader-election-role
+  name: picchu-leader-election-role
 rules:
 - apiGroups:
   - ""

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: leader-election-role
+  name: picchu-leader-election-role
 subjects:
 - kind: ServiceAccount
   name: picchu

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -85,3 +85,9 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - "*"

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -44,6 +44,7 @@ type ClusterReconciler struct {
 
 // +kubebuilder:rbac:groups=picchu.medium.engineering,resources=clusters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=picchu.medium.engineering,resources=clusters/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs="*"
 
 func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()


### PR DESCRIPTION
Fix Missing Leases Permissions in Picchu

During the Wine cluster migration (kubernetes v1.24), we noticed errors in picchu related to the coordination.k8s.io permission.
I added it manually to the RBAC configuration, and it stabilized things.

This codifies it in the actual configs for future deployments.


Manual testing: 'Deployed during cluster migration'