### PR TITLE
'Update Syncer & Incarnation Controllers to sync SLOs outside of Delivery'

### DIFF
--- a/controllers/incarnation.go
+++ b/controllers/incarnation.go
@@ -429,22 +429,44 @@ func (i *Incarnation) deleteCanaryRules(ctx context.Context) error {
 
 func (i *Incarnation) syncTaggedServiceLevels(ctx context.Context) error {
 	if i.picchuConfig.ServiceLevelsFleet != "" && i.picchuConfig.ServiceLevelsNamespace != "" {
-		err := i.controller.applyDeliveryPlan(ctx, "Ensure Service Levels Namespace", &rmplan.EnsureNamespace{
-			Name: i.picchuConfig.ServiceLevelsNamespace,
-		})
-		if err != nil {
-			return err
-		}
+		// Account for a fleet other than Delivery (old way of configuring SLOs) and Production (the only other place we ideally want SLOs to go)
+		if i.picchuConfig.ServiceLevelsFleet == "delivery" {
+			err := i.controller.applyDeliveryPlan(ctx, "Ensure Service Levels Namespace", &rmplan.EnsureNamespace{
+				Name: i.picchuConfig.ServiceLevelsNamespace,
+			})
+			if err != nil {
+				return err
+			}
 
-		return i.controller.applyDeliveryPlan(ctx, "Sync Tagged Service Levels", &rmplan.SyncTaggedServiceLevels{
-			App:                         i.appName(),
-			Target:                      i.targetName(),
-			Namespace:                   i.picchuConfig.ServiceLevelsNamespace,
-			Tag:                         i.tag,
-			Labels:                      i.defaultLabels(),
-			ServiceLevelObjectiveLabels: i.target().ServiceLevelObjectiveLabels,
-			ServiceLevelObjectives:      i.target().SlothServiceLevelObjectives,
-		})
+			return i.controller.applyDeliveryPlan(ctx, "Sync Tagged Service Levels", &rmplan.SyncTaggedServiceLevels{
+				App:                         i.appName(),
+				Target:                      i.targetName(),
+				Namespace:                   i.picchuConfig.ServiceLevelsNamespace,
+				Tag:                         i.tag,
+				Labels:                      i.defaultLabels(),
+				ServiceLevelObjectiveLabels: i.target().ServiceLevelObjectiveLabels,
+				ServiceLevelObjectives:      i.target().SlothServiceLevelObjectives,
+			})
+		} else if i.picchuConfig.ServiceLevelsFleet == "production" {
+			err := i.controller.applyPlan(
+				ctx,
+				"Ensure Service Levels Namespace",
+				$rmplan.EnsureNamespace{Name: i.picchuConfig.ServiceLevelsNamespace}
+			)
+			if err != nil {
+				return err
+			}
+
+			return i.controller.applyPlan(ctx, "Sync Tagged Service Levels", &rmplan.SyncTaggedServiceLevels{
+				App:                         i.appName(),
+				Target:                      i.targetName(),
+				Namespace:                   i.picchuConfig.ServiceLevelsNamespace,
+				Tag:                         i.tag,
+				Labels:                      i.defaultLabels(),
+				ServiceLevelObjectiveLabels: i.target().ServiceLevelObjectiveLabels,
+				ServiceLevelObjectives:      i.target().SlothServiceLevelObjectives,
+			})
+		}
 	}
 
 	i.log.Info("service-levels-fleet and service-levels-namespace not set, skipping SyncTaggedServiceLevels")
@@ -453,13 +475,28 @@ func (i *Incarnation) syncTaggedServiceLevels(ctx context.Context) error {
 
 func (i *Incarnation) deleteTaggedServiceLevels(ctx context.Context) error {
 	if i.picchuConfig.ServiceLevelsFleet != "" && i.picchuConfig.ServiceLevelsNamespace != "" {
-		return i.controller.applyDeliveryPlan(ctx, "Delete Tagged Service Levels", &rmplan.DeleteTaggedServiceLevels{
-			App:       i.appName(),
-			Target:    i.targetName(),
-			Namespace: i.picchuConfig.ServiceLevelsNamespace,
-			Tag:       i.tag,
-		})
+		if i.picchuConfig.ServiceLevelsfleet == "delivery" {
+			// Account for a fleet other than Delivery (old way of configuring SLOs) and Production (the only other place we ideally want SLOs to go)
+			return i.controller.applyDeliveryPlan(ctx, "Delete Tagged Service Levels", &rmplan.DeleteTaggedServiceLevels{
+				App:       i.appName(),
+				Target:    i.targetName(),
+				Namespace: i.picchuConfig.ServiceLevelsNamespace,
+				Tag:       i.tag,
+			})
+		} else if i.picchuConfig.ServiceLevelsFleet == "production" {
+			return i.controller.applyPlan(
+				ctx,
+				"Delete Tagged Service Levels",
+				&rmplan.DeleteTaggedServiceLevels{
+					App:       i.appName(),
+					Target:    i.targetName(),
+					Namespace: i.picchuConfig.ServiceLevelsNamespace,
+					Tag:       i.tag,
+				}
+			)
+		}
 	}
+
 	i.log.Info("service-levels-fleet and service-levels-namespace not set, skipping DeleteTaggedServiceLevels")
 	return nil
 }

--- a/controllers/incarnation.go
+++ b/controllers/incarnation.go
@@ -447,7 +447,7 @@ func (i *Incarnation) syncTaggedServiceLevels(ctx context.Context) error {
 				ServiceLevelObjectiveLabels: i.target().ServiceLevelObjectiveLabels,
 				ServiceLevelObjectives:      i.target().SlothServiceLevelObjectives,
 			})
-		} else if i.picchuConfig.ServiceLevelsFleet == "production" {
+		} else {
 			err := i.controller.applyPlan(
 				ctx,
 				"Ensure Service Levels Namespace",
@@ -483,7 +483,7 @@ func (i *Incarnation) deleteTaggedServiceLevels(ctx context.Context) error {
 				Namespace: i.picchuConfig.ServiceLevelsNamespace,
 				Tag:       i.tag,
 			})
-		} else if i.picchuConfig.ServiceLevelsFleet == "production" {
+		} else {
 			return i.controller.applyPlan(
 				ctx,
 				"Delete Tagged Service Levels",

--- a/controllers/incarnation.go
+++ b/controllers/incarnation.go
@@ -451,7 +451,7 @@ func (i *Incarnation) syncTaggedServiceLevels(ctx context.Context) error {
 			err := i.controller.applyPlan(
 				ctx,
 				"Ensure Service Levels Namespace",
-				$rmplan.EnsureNamespace{Name: i.picchuConfig.ServiceLevelsNamespace}
+				&rmplan.EnsureNamespace{Name: i.picchuConfig.ServiceLevelsNamespace},
 			)
 			if err != nil {
 				return err
@@ -475,7 +475,7 @@ func (i *Incarnation) syncTaggedServiceLevels(ctx context.Context) error {
 
 func (i *Incarnation) deleteTaggedServiceLevels(ctx context.Context) error {
 	if i.picchuConfig.ServiceLevelsFleet != "" && i.picchuConfig.ServiceLevelsNamespace != "" {
-		if i.picchuConfig.ServiceLevelsfleet == "delivery" {
+		if i.picchuConfig.ServiceLevelsFleet == "delivery" {
 			// Account for a fleet other than Delivery (old way of configuring SLOs) and Production (the only other place we ideally want SLOs to go)
 			return i.controller.applyDeliveryPlan(ctx, "Delete Tagged Service Levels", &rmplan.DeleteTaggedServiceLevels{
 				App:       i.appName(),
@@ -492,7 +492,7 @@ func (i *Incarnation) deleteTaggedServiceLevels(ctx context.Context) error {
 					Target:    i.targetName(),
 					Namespace: i.picchuConfig.ServiceLevelsNamespace,
 					Tag:       i.tag,
-				}
+				},
 			)
 		}
 	}

--- a/controllers/incarnation.go
+++ b/controllers/incarnation.go
@@ -430,43 +430,24 @@ func (i *Incarnation) deleteCanaryRules(ctx context.Context) error {
 func (i *Incarnation) syncTaggedServiceLevels(ctx context.Context) error {
 	if i.picchuConfig.ServiceLevelsFleet != "" && i.picchuConfig.ServiceLevelsNamespace != "" {
 		// Account for a fleet other than Delivery (old way of configuring SLOs) and Production (the only other place we ideally want SLOs to go)
-		if i.picchuConfig.ServiceLevelsFleet == "delivery" {
-			err := i.controller.applyDeliveryPlan(ctx, "Ensure Service Levels Namespace", &rmplan.EnsureNamespace{
-				Name: i.picchuConfig.ServiceLevelsNamespace,
-			})
-			if err != nil {
-				return err
-			}
-
-			return i.controller.applyDeliveryPlan(ctx, "Sync Tagged Service Levels", &rmplan.SyncTaggedServiceLevels{
-				App:                         i.appName(),
-				Target:                      i.targetName(),
-				Namespace:                   i.picchuConfig.ServiceLevelsNamespace,
-				Tag:                         i.tag,
-				Labels:                      i.defaultLabels(),
-				ServiceLevelObjectiveLabels: i.target().ServiceLevelObjectiveLabels,
-				ServiceLevelObjectives:      i.target().SlothServiceLevelObjectives,
-			})
-		} else {
-			err := i.controller.applyPlan(
-				ctx,
-				"Ensure Service Levels Namespace",
-				&rmplan.EnsureNamespace{Name: i.picchuConfig.ServiceLevelsNamespace},
-			)
-			if err != nil {
-				return err
-			}
-
-			return i.controller.applyPlan(ctx, "Sync Tagged Service Levels", &rmplan.SyncTaggedServiceLevels{
-				App:                         i.appName(),
-				Target:                      i.targetName(),
-				Namespace:                   i.picchuConfig.ServiceLevelsNamespace,
-				Tag:                         i.tag,
-				Labels:                      i.defaultLabels(),
-				ServiceLevelObjectiveLabels: i.target().ServiceLevelObjectiveLabels,
-				ServiceLevelObjectives:      i.target().SlothServiceLevelObjectives,
-			})
+		err := i.controller.applyPlan(
+			ctx,
+			"Ensure Service Levels Namespace",
+			&rmplan.EnsureNamespace{Name: i.picchuConfig.ServiceLevelsNamespace},
+		)
+		if err != nil {
+			return err
 		}
+
+		return i.controller.applyPlan(ctx, "Sync Tagged Service Levels", &rmplan.SyncTaggedServiceLevels{
+			App:                         i.appName(),
+			Target:                      i.targetName(),
+			Namespace:                   i.picchuConfig.ServiceLevelsNamespace,
+			Tag:                         i.tag,
+			Labels:                      i.defaultLabels(),
+			ServiceLevelObjectiveLabels: i.target().ServiceLevelObjectiveLabels,
+			ServiceLevelObjectives:      i.target().SlothServiceLevelObjectives,
+		})
 	}
 
 	i.log.Info("service-levels-fleet and service-levels-namespace not set, skipping SyncTaggedServiceLevels")
@@ -475,28 +456,17 @@ func (i *Incarnation) syncTaggedServiceLevels(ctx context.Context) error {
 
 func (i *Incarnation) deleteTaggedServiceLevels(ctx context.Context) error {
 	if i.picchuConfig.ServiceLevelsFleet != "" && i.picchuConfig.ServiceLevelsNamespace != "" {
-		if i.picchuConfig.ServiceLevelsFleet == "delivery" {
-			// Account for a fleet other than Delivery (old way of configuring SLOs) and Production (the only other place we ideally want SLOs to go)
-			return i.controller.applyDeliveryPlan(ctx, "Delete Tagged Service Levels", &rmplan.DeleteTaggedServiceLevels{
+		return i.controller.applyPlan(
+			ctx,
+			"Delete Tagged Service Levels",
+			&rmplan.DeleteTaggedServiceLevels{
 				App:       i.appName(),
 				Target:    i.targetName(),
 				Namespace: i.picchuConfig.ServiceLevelsNamespace,
 				Tag:       i.tag,
-			})
-		} else {
-			return i.controller.applyPlan(
-				ctx,
-				"Delete Tagged Service Levels",
-				&rmplan.DeleteTaggedServiceLevels{
-					App:       i.appName(),
-					Target:    i.targetName(),
-					Namespace: i.picchuConfig.ServiceLevelsNamespace,
-					Tag:       i.tag,
-				},
-			)
-		}
+			},
+		)
 	}
-
 	i.log.Info("service-levels-fleet and service-levels-namespace not set, skipping DeleteTaggedServiceLevels")
 	return nil
 }

--- a/controllers/syncer.go
+++ b/controllers/syncer.go
@@ -311,19 +311,11 @@ func (r *ResourceSyncer) syncServiceMonitors(ctx context.Context) error {
 }
 
 func (r *ResourceSyncer) delServiceLevels(ctx context.Context) error {
-	if r.picchuConfig.ServiceLevelsFleet == "delivery" {
-		return r.applyDeliveryPlan(ctx, "Delete App ServiceLevels", &rmplan.DeleteServiceLevels{
-			App:       r.instance.Spec.App,
-			Target:    r.instance.Spec.Target,
-			Namespace: r.picchuConfig.ServiceLevelsNamespace,
-		})
-	} else {
-		return r.applyPlan(ctx, "Delete App ServiceLevels", &rmplan.DeleteServiceLevels{
-			App:       r.instance.Spec.App,
-			Target:    r.instance.Spec.Target,
-			Namespace: r.picchuConfig.ServiceLevelsNamespace,
-		})
-	}
+	return r.applyPlan(ctx, "Delete App ServiceLevels", &rmplan.DeleteServiceLevels{
+		App:       r.instance.Spec.App,
+		Target:    r.instance.Spec.Target,
+		Namespace: r.picchuConfig.ServiceLevelsNamespace,
+	})
 }
 
 func (r *ResourceSyncer) syncServiceLevels(ctx context.Context) error {
@@ -331,52 +323,28 @@ func (r *ResourceSyncer) syncServiceLevels(ctx context.Context) error {
 		slos, sloLabels := r.prepareServiceLevelObjectives()
 		// Make a decision on where to apply the serviceLevels based on the Fleets.
 		// Necessary after the kubernetes migration to v1.24.
-		if r.picchuConfig.ServiceLevelsFleet == "delivery" {
-			if len(slos) > 0 {
-				if err := r.applyDeliveryPlan(ctx, "Ensure Service Levels Namespace", &rmplan.EnsureNamespace{
-					Name: r.picchuConfig.ServiceLevelsNamespace,
-				}); err != nil {
-					return err
-				}
+		if len(slos) > 0 {
+			if err := r.applyPlan(ctx, "Ensure Service Levels Namespace", &rmplan.EnsureNamespace{
+				Name: r.picchuConfig.ServiceLevelsNamespace,
+			}); err != nil {
+				return err
+			}
 
-				labels := r.defaultLabels()
-				labels[picchuv1alpha1.LabelTarget] = r.instance.Spec.Target
+			labels := r.defaultLabels()
+			labels[picchuv1alpha1.LabelTarget] = r.instance.Spec.Target
 
-				if err := r.applyDeliveryPlan(ctx, "Sync App ServiceLevels", &rmplan.SyncServiceLevels{
-					App:                         r.instance.Spec.App,
-					Target:                      r.instance.Spec.Target,
-					Namespace:                   r.picchuConfig.ServiceLevelsNamespace,
-					Labels:                      labels,
-					ServiceLevelObjectiveLabels: sloLabels,
-					ServiceLevelObjectives:      slos,
-				}); err != nil {
-					return err
-				}
-			} else {
-				return r.delServiceLevels(ctx)
+			if err := r.applyPlan(ctx, "Sync App ServiceLevels", &rmplan.SyncServiceLevels{
+				App:                         r.instance.Spec.App,
+				Target:                      r.instance.Spec.Target,
+				Namespace:                   r.picchuConfig.ServiceLevelsNamespace,
+				Labels:                      labels,
+				ServiceLevelObjectiveLabels: sloLabels,
+				ServiceLevelObjectives:      slos,
+			}); err != nil {
+				return err
 			}
 		} else {
-			if len(slos) > 0 {
-				if err := r.applyPlan(ctx, "Ensure Service Levels Namespace", &rmplan.EnsureNamespace{
-					Name: r.picchuConfig.ServiceLevelsNamespace,
-				}); err != nil {
-					return err
-				}
-
-				labels := r.defaultLabels()
-				labels[picchuv1alpha1.LabelTarget] = r.instance.Spec.Target
-
-				if err := r.applyPlan(ctx, "Sync App ServiceLevels", &rmplan.SyncServiceLevels{
-					App:                         r.instance.Spec.App,
-					Target:                      r.instance.Spec.Target,
-					Namespace:                   r.picchuConfig.ServiceLevelsNamespace,
-					Labels:                      labels,
-					ServiceLevelObjectiveLabels: sloLabels,
-					ServiceLevelObjectives:      slos,
-				}); err != nil {
-					return err
-				}
-			}
+			return r.delServiceLevels(ctx)
 		}
 	} else {
 		r.log.Info("service-levels-fleet and service-levels-namespace not set, skipping SyncServiceLevels")

--- a/controllers/syncer.go
+++ b/controllers/syncer.go
@@ -355,7 +355,7 @@ func (r *ResourceSyncer) syncServiceLevels(ctx context.Context) error {
 			} else {
 				return r.delServiceLevels(ctx)
 			}
-		} else if r.picchuConfig.ServiceLevelsFleet == "production" {
+		} else {
 			if len(slos) > 0 {
 				if err := r.applyPlan(ctx, "Ensure Service Levels Namespace", &rmplan.EnsureNamespace{
 					Name: r.picchuConfig.ServiceLevelsNamespace,

--- a/controllers/syncer.go
+++ b/controllers/syncer.go
@@ -311,38 +311,72 @@ func (r *ResourceSyncer) syncServiceMonitors(ctx context.Context) error {
 }
 
 func (r *ResourceSyncer) delServiceLevels(ctx context.Context) error {
-	return r.applyDeliveryPlan(ctx, "Delete App ServiceLevels", &rmplan.DeleteServiceLevels{
-		App:       r.instance.Spec.App,
-		Target:    r.instance.Spec.Target,
-		Namespace: r.picchuConfig.ServiceLevelsNamespace,
-	})
+	if r.picchuConfig.ServiceLevelsFleet == "delivery" {
+		return r.applyDeliveryPlan(ctx, "Delete App ServiceLevels", &rmplan.DeleteServiceLevels{
+			App:       r.instance.Spec.App,
+			Target:    r.instance.Spec.Target,
+			Namespace: r.picchuConfig.ServiceLevelsNamespace,
+		})
+	} else if r.picchuConfig.ServiceLevelsFleet == "production" {
+		return r.applyPlan(ctx, "Delete App ServiceLevels", &rmplan.DeleteServiceLevels{
+			App:       r.instance.Spec.App,
+			Target:    r.instance.Spec.Target,
+			Namespace: r.picchuConfig.ServiceLevelsNamespace,
+		})
+	}
 }
 
 func (r *ResourceSyncer) syncServiceLevels(ctx context.Context) error {
 	if r.picchuConfig.ServiceLevelsFleet != "" && r.picchuConfig.ServiceLevelsNamespace != "" {
 		slos, sloLabels := r.prepareServiceLevelObjectives()
-		if len(slos) > 0 {
-			if err := r.applyDeliveryPlan(ctx, "Ensure Service Levels Namespace", &rmplan.EnsureNamespace{
-				Name: r.picchuConfig.ServiceLevelsNamespace,
-			}); err != nil {
-				return err
-			}
+		// Make a decision on where to apply the serviceLevels based on the Fleets.
+		// Necessary after the kubernetes migration to v1.24.
+		if r.picchuConfig.ServiceLevelsFleet == "delivery" {
+			if len(slos) > 0 {
+				if err := r.applyDeliveryPlan(ctx, "Ensure Service Levels Namespace", &rmplan.EnsureNamespace{
+					Name: r.picchuConfig.ServiceLevelsNamespace,
+				}); err != nil {
+					return err
+				}
 
-			labels := r.defaultLabels()
-			labels[picchuv1alpha1.LabelTarget] = r.instance.Spec.Target
+				labels := r.defaultLabels()
+				labels[picchuv1alpha1.LabelTarget] = r.instance.Spec.Target
 
-			if err := r.applyDeliveryPlan(ctx, "Sync App ServiceLevels", &rmplan.SyncServiceLevels{
-				App:                         r.instance.Spec.App,
-				Target:                      r.instance.Spec.Target,
-				Namespace:                   r.picchuConfig.ServiceLevelsNamespace,
-				Labels:                      labels,
-				ServiceLevelObjectiveLabels: sloLabels,
-				ServiceLevelObjectives:      slos,
-			}); err != nil {
-				return err
+				if err := r.applyDeliveryPlan(ctx, "Sync App ServiceLevels", &rmplan.SyncServiceLevels{
+					App:                         r.instance.Spec.App,
+					Target:                      r.instance.Spec.Target,
+					Namespace:                   r.picchuConfig.ServiceLevelsNamespace,
+					Labels:                      labels,
+					ServiceLevelObjectiveLabels: sloLabels,
+					ServiceLevelObjectives:      slos,
+				}); err != nil {
+					return err
+				}
+			} else {
+				return r.delServiceLevels(ctx)
 			}
-		} else {
-			return r.delServiceLevels(ctx)
+		} else if r.picchuConfig.ServiceLevelsFleet == "production" {
+			if len(slos) > 0 {
+				if err := r.applyPlan(ctx, "Ensure Service Levels Namespace", &rmplan.EnsureNamespace{
+					Name: r.picchuConfig.ServiceLevelsNamespace,
+				}); err != nil {
+					return err
+				}
+
+				labels := r.defaultLabels()
+				labels[picchuv1alpha1.LabelTarget] = r.instance.Spec.Target
+
+				if err := r.applyPlan(ctx, "Sync App ServiceLevels", &rmplan.SyncServiceLevels{
+					App:                         r.instance.Spec.App,
+					Target:                      r.instance.Spec.Target,
+					Namespace:                   r.picchuConfig.ServiceLevelsNamespace,
+					Labels:                      labels,
+					ServiceLevelObjectiveLabels: sloLabels,
+					ServiceLevelObjectives:      slos,
+				}); err != nil {
+					return err
+				}
+			}
 		}
 	} else {
 		r.log.Info("service-levels-fleet and service-levels-namespace not set, skipping SyncServiceLevels")

--- a/controllers/syncer.go
+++ b/controllers/syncer.go
@@ -317,7 +317,7 @@ func (r *ResourceSyncer) delServiceLevels(ctx context.Context) error {
 			Target:    r.instance.Spec.Target,
 			Namespace: r.picchuConfig.ServiceLevelsNamespace,
 		})
-	} else if r.picchuConfig.ServiceLevelsFleet == "production" {
+	} else {
 		return r.applyPlan(ctx, "Delete App ServiceLevels", &rmplan.DeleteServiceLevels{
 			App:       r.instance.Spec.App,
 			Target:    r.instance.Spec.Target,
@@ -491,7 +491,7 @@ func (r *ResourceSyncer) prepareRevisions() []rmplan.Revision {
 		incarnation.updateCurrentPercent(0)
 	}
 
-	// The idea here is we will work through releases from newest to oldest,
+	// The idea here is we will work through releases from newest to oldest
 	// incrementing their weight if enough time has passed since their last
 	// update, and stopping when we reach 100%. This will cause newer releases
 	// to take from oldest fnord release.


### PR DESCRIPTION
Updates to How Picchu Synchronizes SLO Objects

Currently, Picchu is only creating SLO objects ( `github.com/slok/sloth/pkg/kubernetes/api/sloth/v1` ) in the Delivery cluster.
This is a pretty big problem, because that means that the downstream objects related to SLO alerts are not in being built on the correct prometheus instances.

The flow is this:

Picchu --> New SLO object (Sloth) on Delivery --> Sloth (on Delivery) creates outputs that are Prometheus recording & alert rules
The output alert & recording rules are based off of metrics *in the production clusters* and only exist on delivery.  The Delivery prometheus instances have no way of querying the metrics in the production clusters, so SLOs are broken as a result.

The options to address were
- Find a way to deploy Federated Prometheus (high-complexity, redeploy of all prometheuses in SLO)
- Update Picchu so that it deploys SLO objects to the production clusters, AND also install Sloth to production clusters so it can create the downstream recording & alert rules

We took the latter since it should be lower-effort and we aren't changing prometheus behaviors (and we can revisit this again down the road).

This PR makes the updates to how Picchu chooses to apply the service levels, and accounts for which Fleet is passed into its `service-levels-fleet` argument.


Manual testing: 🚫