### PR TITLE
support for PodDisruptionBudgets

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -69,6 +69,8 @@ const (
 
 	AutoscalerTypeHPA = "hpa"
 	AutoscalerTypeWPA = "wpa"
+
+	MaxUnavailable = "25%"
 )
 
 type PortInfo struct {

--- a/api/v1alpha1/revision_types.go
+++ b/api/v1alpha1/revision_types.go
@@ -23,6 +23,7 @@ import (
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -92,7 +93,8 @@ type RevisionTarget struct {
 	Ports               []PortInfo        `json:"ports,omitempty"`
 	Env                 []corev1.EnvVar   `json:"env,omitempty"`
 
-	Istio *Istio `json:"istio,omitempty"`
+	Istio               *Istio                        `json:"istio,omitempty"`
+	PodDisruptionBudget *policyv1.PodDisruptionBudget `json:"podDisruptionBudget,omitempty"`
 }
 
 type ExternalTest struct {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -24,6 +24,7 @@ package v1alpha1
 import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -1441,6 +1442,11 @@ func (in *RevisionTarget) DeepCopyInto(out *RevisionTarget) {
 	if in.Istio != nil {
 		in, out := &in.Istio, &out.Istio
 		*out = new(Istio)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.PodDisruptionBudget != nil {
+		in, out := &in.PodDisruptionBudget, &out.PodDisruptionBudget
+		*out = new(policyv1.PodDisruptionBudget)
 		(*in).DeepCopyInto(*out)
 	}
 }

--- a/config/crd/bases/picchu.medium.engineering_revisions.yaml
+++ b/config/crd/bases/picchu.medium.engineering_revisions.yaml
@@ -2911,6 +2911,282 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                    podDisruptionBudget:
+                      description: PodDisruptionBudget is an object to define the
+                        max disruption that can be caused to a collection of pods
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of
+                            this representation of an object. Servers should convert
+                            recognized schemas to the latest internal value, and may
+                            reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST
+                            resource this object represents. Servers may infer this
+                            from the endpoint the client submits requests to. Cannot
+                            be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        metadata:
+                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                          type: object
+                        spec:
+                          description: Specification of the desired behavior of the
+                            PodDisruptionBudget.
+                          properties:
+                            maxUnavailable:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: An eviction is allowed if at most "maxUnavailable"
+                                pods selected by "selector" are unavailable after
+                                the eviction, i.e. even in absence of the evicted
+                                pod. For example, one can prevent all voluntary evictions
+                                by specifying 0. This is a mutually exclusive setting
+                                with "minAvailable".
+                              x-kubernetes-int-or-string: true
+                            minAvailable:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: An eviction is allowed if at least "minAvailable"
+                                pods selected by "selector" will still be available
+                                after the eviction, i.e. even in the absence of the
+                                evicted pod.  So for example you can prevent all voluntary
+                                evictions by specifying "100%".
+                              x-kubernetes-int-or-string: true
+                            selector:
+                              description: Label query over pods whose evictions are
+                                managed by the disruption budget. A null selector
+                                will match no pods, while an empty ({}) selector will
+                                select all pods within the namespace.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            unhealthyPodEvictionPolicy:
+                              description: "UnhealthyPodEvictionPolicy defines the
+                                criteria for when unhealthy pods should be considered
+                                for eviction. Current implementation considers healthy
+                                pods, as pods that have status.conditions item with
+                                type=\"Ready\",status=\"True\". \n Valid policies
+                                are IfHealthyBudget and AlwaysAllow. If no policy
+                                is specified, the default behavior will be used, which
+                                corresponds to the IfHealthyBudget policy. \n IfHealthyBudget
+                                policy means that running pods (status.phase=\"Running\"),
+                                but not yet healthy can be evicted only if the guarded
+                                application is not disrupted (status.currentHealthy
+                                is at least equal to status.desiredHealthy). Healthy
+                                pods will be subject to the PDB for eviction. \n AlwaysAllow
+                                policy means that all running pods (status.phase=\"Running\"),
+                                but not yet healthy are considered disrupted and can
+                                be evicted regardless of whether the criteria in a
+                                PDB is met. This means perspective running pods of
+                                a disrupted application might not get a chance to
+                                become healthy. Healthy pods will be subject to the
+                                PDB for eviction. \n Additional policies may be added
+                                in the future. Clients making eviction decisions should
+                                disallow eviction of unhealthy pods if they encounter
+                                an unrecognized policy in this field. \n This field
+                                is alpha-level. The eviction API uses this field when
+                                the feature gate PDBUnhealthyPodEvictionPolicy is
+                                enabled (disabled by default)."
+                              type: string
+                          type: object
+                        status:
+                          description: Most recently observed status of the PodDisruptionBudget.
+                          properties:
+                            conditions:
+                              description: 'Conditions contain conditions for PDB.
+                                The disruption controller sets the DisruptionAllowed
+                                condition. The following are known values for the
+                                reason field (additional reasons could be added in
+                                the future): - SyncFailed: The controller encountered
+                                an error and wasn''t able to compute the number of
+                                allowed disruptions. Therefore no disruptions are
+                                allowed and the status of the condition will be False.
+                                - InsufficientPods: The number of pods are either
+                                at or below the number required by the PodDisruptionBudget.
+                                No disruptions are allowed and the status of the condition
+                                will be False. - SufficientPods: There are more pods
+                                than required by the PodDisruptionBudget. The condition
+                                will be True, and the number of allowed disruptions
+                                are provided by the disruptionsAllowed property.'
+                              items:
+                                description: "Condition contains details for one aspect
+                                  of the current state of this API Resource. --- This
+                                  struct is intended for direct use as an array at
+                                  the field path .status.conditions.  For example,
+                                  \n type FooStatus struct{ // Represents the observations
+                                  of a foo's current state. // Known .status.conditions.type
+                                  are: \"Available\", \"Progressing\", and \"Degraded\"
+                                  // +patchMergeKey=type // +patchStrategy=merge //
+                                  +listType=map // +listMapKey=type Conditions []metav1.Condition
+                                  `json:\"conditions,omitempty\" patchStrategy:\"merge\"
+                                  patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                                  \n // other fields }"
+                                properties:
+                                  lastTransitionTime:
+                                    description: lastTransitionTime is the last time
+                                      the condition transitioned from one status to
+                                      another. This should be when the underlying
+                                      condition changed.  If that is not known, then
+                                      using the time when the API field changed is
+                                      acceptable.
+                                    format: date-time
+                                    type: string
+                                  message:
+                                    description: message is a human readable message
+                                      indicating details about the transition. This
+                                      may be an empty string.
+                                    maxLength: 32768
+                                    type: string
+                                  observedGeneration:
+                                    description: observedGeneration represents the
+                                      .metadata.generation that the condition was
+                                      set based upon. For instance, if .metadata.generation
+                                      is currently 12, but the .status.conditions[x].observedGeneration
+                                      is 9, the condition is out of date with respect
+                                      to the current state of the instance.
+                                    format: int64
+                                    minimum: 0
+                                    type: integer
+                                  reason:
+                                    description: reason contains a programmatic identifier
+                                      indicating the reason for the condition's last
+                                      transition. Producers of specific condition
+                                      types may define expected values and meanings
+                                      for this field, and whether the values are considered
+                                      a guaranteed API. The value should be a CamelCase
+                                      string. This field may not be empty.
+                                    maxLength: 1024
+                                    minLength: 1
+                                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                    type: string
+                                  status:
+                                    description: status of the condition, one of True,
+                                      False, Unknown.
+                                    enum:
+                                    - "True"
+                                    - "False"
+                                    - Unknown
+                                    type: string
+                                  type:
+                                    description: type of condition in CamelCase or
+                                      in foo.example.com/CamelCase. --- Many .condition.type
+                                      values are consistent across resources like
+                                      Available, but because arbitrary conditions
+                                      can be useful (see .node.status.conditions),
+                                      the ability to deconflict is important. The
+                                      regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                                    maxLength: 316
+                                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                    type: string
+                                required:
+                                - lastTransitionTime
+                                - message
+                                - reason
+                                - status
+                                - type
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - type
+                              x-kubernetes-list-type: map
+                            currentHealthy:
+                              description: current number of healthy pods
+                              format: int32
+                              type: integer
+                            desiredHealthy:
+                              description: minimum desired number of healthy pods
+                              format: int32
+                              type: integer
+                            disruptedPods:
+                              additionalProperties:
+                                format: date-time
+                                type: string
+                              description: DisruptedPods contains information about
+                                pods whose eviction was processed by the API server
+                                eviction subresource handler but has not yet been
+                                observed by the PodDisruptionBudget controller. A
+                                pod will be in this map from the time when the API
+                                server processed the eviction request to the time
+                                when the pod is seen by PDB controller as having been
+                                marked for deletion (or after a timeout). The key
+                                in the map is the name of the pod and the value is
+                                the time when the API server processed the eviction
+                                request. If the deletion didn't occur and a pod is
+                                still there it will be removed from the list automatically
+                                by PodDisruptionBudget controller after some time.
+                                If everything goes smooth this map should be empty
+                                for the most of the time. Large number of entries
+                                in the map may indicate problems with pod deletions.
+                              type: object
+                            disruptionsAllowed:
+                              description: Number of pod disruptions that are currently
+                                allowed.
+                              format: int32
+                              type: integer
+                            expectedPods:
+                              description: total number of pods counted by this disruption
+                                budget
+                              format: int32
+                              type: integer
+                            observedGeneration:
+                              description: Most recent generation observed when updating
+                                this PDB status. DisruptionsAllowed and other status
+                                information is valid only if observedGeneration equals
+                                to PDB's object generation.
+                              format: int64
+                              type: integer
+                          required:
+                          - currentHealthy
+                          - desiredHealthy
+                          - disruptionsAllowed
+                          - expectedPods
+                          type: object
+                      type: object
                     ports:
                       items:
                         properties:

--- a/controllers/plan/init_test.go
+++ b/controllers/plan/init_test.go
@@ -17,6 +17,7 @@ import (
 	apps "k8s.io/api/apps/v1"
 	autoscaling "k8s.io/api/autoscaling/v2"
 	core "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -68,6 +69,9 @@ func init() {
 			panic(err)
 		}
 		if err := wpav1.AddToScheme(s); err != nil {
+			panic(err)
+		}
+		if err := policyv1.AddToScheme(s); err != nil {
 			panic(err)
 		}
 	}

--- a/controllers/plan/syncRevision_test.go
+++ b/controllers/plan/syncRevision_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -18,6 +19,7 @@ import (
 )
 
 var (
+	maxUnavailable      = intstr.FromString("25%")
 	defaultRevisionPlan = &SyncRevision{
 		App:       "testapp",
 		Tag:       "testtag",
@@ -107,6 +109,18 @@ var (
 			{
 				Name:      "shm",
 				MountPath: "/dev/shm",
+			},
+		},
+		PodDisruptionBudget: &policyv1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "testapp",
+				Namespace: "testnamespace",
+				Labels: map[string]string{
+					"test": "label",
+				},
+			},
+			Spec: policyv1.PodDisruptionBudgetSpec{
+				MaxUnavailable: &maxUnavailable,
 			},
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ import (
 	apps "k8s.io/api/apps/v1"
 	autoscaling "k8s.io/api/autoscaling/v2"
 	core "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -123,6 +124,7 @@ func main() {
 		slo.AddToScheme,
 		wpav1.AddToScheme,
 		apis.AddToScheme,
+		policyv1.AddToScheme,
 	}
 
 	for _, sch := range []*k8sruntime.Scheme{clientgoscheme.Scheme} {


### PR DESCRIPTION

Manual testing: 🚫

This PR adds support for PodDisruptionBudgets(pdb) as an optional field in the RevisionTarget. If a pdb has not been defined, a default pdb will be provisioned with a MaxUnavailable of 25%, in other words no less than 75% available pods will be voluntary disrupted at a given time. 