### PR TITLE
Revert "[INF-188] 'Update Picchu to account for empty TrafficPolicy objects when applying DestinationRule objects'"

### DIFF
--- a/controllers/plan/syncApp.go
+++ b/controllers/plan/syncApp.go
@@ -511,27 +511,12 @@ func (p *SyncApp) destinationRule() *istioclient.DestinationRule {
 	labelTag := "tag.picchu.medium.engineering"
 	var subsets []*istio.Subset
 	for _, revision := range p.DeployedRevisions {
-		newSubset := &istio.Subset{}
-
-		// Check for an empty istio trafficPolicy object, and ONLY add it to the istio subset object
-		// if it's non-empty. Else, do not include it. The subset can be created without it, and we are
-		// seeing a breakage.  In kbfd, the TrafficPolicy is only updated with PortLevelSettings
-		// Ref the go pkg here: https://pkg.go.dev/istio.io/api@v1.19.0/networking/v1alpha3#TrafficPolicy
-		if len(revision.TrafficPolicy.PortLevelSettings) > 0 {
-			newSubset = &istio.Subset{
-				Name:          revision.Tag,
-				Labels:        map[string]string{labelTag: revision.Tag},
-				TrafficPolicy: revision.TrafficPolicy,
-			}
-		} else {
-			newSubset = &istio.Subset{
-				Name:   revision.Tag,
-				Labels: map[string]string{labelTag: revision.Tag},
-			}
-		}
-		subsets = append(subsets, newSubset)
+		subsets = append(subsets, &istio.Subset{
+			Name:          revision.Tag,
+			Labels:        map[string]string{labelTag: revision.Tag},
+			TrafficPolicy: revision.TrafficPolicy,
+		})
 	}
-
 	return &istioclient.DestinationRule{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      p.App,

--- a/controllers/plan/syncApp_test.go
+++ b/controllers/plan/syncApp_test.go
@@ -43,11 +43,9 @@ var (
 				Weight:           100,
 				TagRoutingHeader: "TEST-TAG",
 				TrafficPolicy: &istio.TrafficPolicy{
-					PortLevelSettings: []*istio.TrafficPolicy_PortTrafficPolicy{
-						{
-							ConnectionPool: &istio.ConnectionPoolSettings{
-								Tcp: &istio.ConnectionPoolSettings_TCPSettings{MaxConnections: 100},
-							},
+					ConnectionPool: &istio.ConnectionPoolSettings{
+						Tcp: &istio.ConnectionPoolSettings_TCPSettings{
+							MaxConnections: 100,
 						},
 					},
 				},
@@ -314,11 +312,9 @@ var (
 					Name:   "testtag",
 					Labels: map[string]string{"tag.picchu.medium.engineering": "testtag"},
 					TrafficPolicy: &istio.TrafficPolicy{
-						PortLevelSettings: []*istio.TrafficPolicy_PortTrafficPolicy{
-							{
-								ConnectionPool: &istio.ConnectionPoolSettings{
-									Tcp: &istio.ConnectionPoolSettings_TCPSettings{MaxConnections: 100},
-								},
+						ConnectionPool: &istio.ConnectionPoolSettings{
+							Tcp: &istio.ConnectionPoolSettings_TCPSettings{
+								MaxConnections: 100,
 							},
 						},
 					},


### PR DESCRIPTION
Reverts Medium/picchu#392