### PR TITLE
decrease max disruption to 5%

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -70,7 +70,7 @@ const (
 	AutoscalerTypeHPA = "hpa"
 	AutoscalerTypeWPA = "wpa"
 
-	MaxUnavailable = "25%"
+	MaxUnavailable = "5%"
 )
 
 type PortInfo struct {

--- a/controllers/plan/syncRevision_test.go
+++ b/controllers/plan/syncRevision_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	maxUnavailable      = intstr.FromString("25%")
+	maxUnavailable      = intstr.FromString("5%")
 	defaultRevisionPlan = &SyncRevision{
 		App:       "testapp",
 		Tag:       "testtag",


### PR DESCRIPTION

Manual testing: 🚫