### PR TITLE
lower pod disruption budget

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -70,7 +70,7 @@ const (
 	AutoscalerTypeHPA = "hpa"
 	AutoscalerTypeWPA = "wpa"
 
-	MaxUnavailable = "5%"
+	MaxUnavailable = "1%"
 )
 
 type PortInfo struct {


### PR DESCRIPTION

Manual testing: 🚫