### PR TITLE
[INF-162] Update the DeleteServiceLevels so that it truly filters for untagged SLOs

### DIFF
--- a/controllers/plan/deleteServiceLevels.go
+++ b/controllers/plan/deleteServiceLevels.go
@@ -26,6 +26,7 @@ func (p *DeleteServiceLevels) Apply(ctx context.Context, cli client.Client, clus
 		LabelSelector: labels.SelectorFromSet(map[string]string{
 			picchuv1alpha1.LabelApp:    p.App,
 			picchuv1alpha1.LabelTarget: p.Target,
+			picchuv1alpha1.LabelTag: "",
 		}),
 	}
 

--- a/controllers/plan/deleteServiceLevels.go
+++ b/controllers/plan/deleteServiceLevels.go
@@ -26,7 +26,7 @@ func (p *DeleteServiceLevels) Apply(ctx context.Context, cli client.Client, clus
 		LabelSelector: labels.SelectorFromSet(map[string]string{
 			picchuv1alpha1.LabelApp:    p.App,
 			picchuv1alpha1.LabelTarget: p.Target,
-			picchuv1alpha1.LabelTag: "",
+			picchuv1alpha1.LabelTag:    "",
 		}),
 	}
 

--- a/controllers/plan/deleteServiceLevels_test.go
+++ b/controllers/plan/deleteServiceLevels_test.go
@@ -31,6 +31,7 @@ func TestDeleteServiceLevels(t *testing.T) {
 			Labels: map[string]string{
 				picchu.LabelApp:    deleteServiceLevels.App,
 				picchu.LabelTarget: deleteServiceLevels.Target,
+				picchu.LabelTag:    "",
 			},
 		},
 	}


### PR DESCRIPTION
# Add a Kubernetes Label Filter that Includes Tag Label for SLO Deletion

## The Problem
Picchu's method for deleting SLO objects currently only filters by app and target. The problem there is that it was catching more than the SLO objects we are expecting. 

This PR updates that method so that it filters by an additional Kubernetes Label (Tag) so that it ONLY will delete the SLO object if that tag is empty. 
I also updated the test since we got an unexpected result on the test when I added this change. Now it's accounted for across both files.


Manual testing: 'Compared label filtering using kubectl to replicate what Picchu does when filtering SLO objects'