### PR TITLE
[INF-162] 'Revert Change to Delete All Prometheus Recording Rules to fix Canary and SLO Rules'

### DIFF
--- a/controllers/plan/sloConfig.go
+++ b/controllers/plan/sloConfig.go
@@ -86,9 +86,9 @@ func (s *SLOConfig) taggedSLISource() *slov1alpha1.SLIEvents {
 }
 
 func (s *SLOConfig) serviceLevelTaggedTotalQuery() string {
-	return fmt.Sprintf("sum(rate(%s{%s=\"%s\"}[{{.window}}]))", s.totalQuery(), s.SLO.ServiceLevelIndicator.TagKey, s.Tag)
+	return fmt.Sprintf("sum(rate(%s{%s=\"%s\"}[{{.window}}]))", s.SLO.ServiceLevelIndicator.TotalQuery, s.SLO.ServiceLevelIndicator.TagKey, s.Tag)
 }
 
 func (s *SLOConfig) serviceLevelTaggedErrorQuery() string {
-	return fmt.Sprintf("sum(rate(%s{%s=\"%s\"}[{{.window}}]))", s.errorQuery(), s.SLO.ServiceLevelIndicator.TagKey, s.Tag)
+	return fmt.Sprintf("sum(rate(%s{%s=\"%s\"}[{{.window}}]))", s.SLO.ServiceLevelIndicator.ErrorQuery, s.SLO.ServiceLevelIndicator.TagKey, s.Tag)
 }

--- a/controllers/plan/sloConfig.go
+++ b/controllers/plan/sloConfig.go
@@ -86,9 +86,9 @@ func (s *SLOConfig) taggedSLISource() *slov1alpha1.SLIEvents {
 }
 
 func (s *SLOConfig) serviceLevelTaggedTotalQuery() string {
-	return fmt.Sprintf("sum(rate(%s{%s=\"%s\"}[{{.window}}]))", s.SLO.ServiceLevelIndicator.TotalQuery, s.SLO.ServiceLevelIndicator.TagKey, s.Tag)
+	return fmt.Sprintf("sum(rate(%s{%s=\"%s\"}[{{.window}}]))", s.totalQuery(), s.SLO.ServiceLevelIndicator.TagKey, s.Tag)
 }
 
 func (s *SLOConfig) serviceLevelTaggedErrorQuery() string {
-	return fmt.Sprintf("sum(rate(%s{%s=\"%s\"}[{{.window}}]))", s.SLO.ServiceLevelIndicator.ErrorQuery, s.SLO.ServiceLevelIndicator.TagKey, s.Tag)
+	return fmt.Sprintf("sum(rate(%s{%s=\"%s\"}[{{.window}}]))", s.errorQuery(), s.SLO.ServiceLevelIndicator.TagKey, s.Tag)
 }

--- a/controllers/plan/syncCanaryRules.go
+++ b/controllers/plan/syncCanaryRules.go
@@ -155,9 +155,9 @@ func (s *SLOConfig) canaryAlertName() string {
 
 func (s *SLOConfig) canaryQuery(log logr.Logger) string {
 	return fmt.Sprintf("%s{%s=\"%s\"} / %s{%s=\"%s\"} - %v > ignoring(%s) sum(%s) / sum(%s)",
-		s.errorQuery(), s.SLO.ServiceLevelIndicator.TagKey, s.Tag,
-		s.totalQuery(), s.SLO.ServiceLevelIndicator.TagKey, s.Tag,
-		s.formatAllowancePercent(log), s.SLO.ServiceLevelIndicator.TagKey, s.errorQuery(), s.totalQuery())
+		s.SLO.ServiceLevelIndicator.ErrorQuery, s.SLO.ServiceLevelIndicator.TagKey, s.Tag,
+		s.SLO.ServiceLevelIndicator.TotalQuery, s.SLO.ServiceLevelIndicator.TagKey, s.Tag,
+		s.formatAllowancePercent(log), s.SLO.ServiceLevelIndicator.TagKey, s.SLO.ServiceLevelIndicator.ErrorQuery, s.SLO.ServiceLevelIndicator.TotalQuery)
 }
 
 func (s *SLOConfig) formatAllowancePercent(log logr.Logger) string {

--- a/controllers/plan/syncCanaryRules.go
+++ b/controllers/plan/syncCanaryRules.go
@@ -155,9 +155,10 @@ func (s *SLOConfig) canaryAlertName() string {
 
 func (s *SLOConfig) canaryQuery(log logr.Logger) string {
 	return fmt.Sprintf("%s{%s=\"%s\"} / %s{%s=\"%s\"} - %v > ignoring(%s) sum(%s) / sum(%s)",
-		s.SLO.ServiceLevelIndicator.ErrorQuery, s.SLO.ServiceLevelIndicator.TagKey, s.Tag,
-		s.SLO.ServiceLevelIndicator.TotalQuery, s.SLO.ServiceLevelIndicator.TagKey, s.Tag,
-		s.formatAllowancePercent(log), s.SLO.ServiceLevelIndicator.TagKey, s.SLO.ServiceLevelIndicator.ErrorQuery, s.SLO.ServiceLevelIndicator.TotalQuery)
+		s.errorQuery(), s.SLO.ServiceLevelIndicator.TagKey, s.Tag,
+		s.totalQuery(), s.SLO.ServiceLevelIndicator.TagKey, s.Tag,
+		s.formatAllowancePercent(log), s.SLO.ServiceLevelIndicator.TagKey, s.errorQuery(), s.totalQuery(),
+	)
 }
 
 func (s *SLOConfig) formatAllowancePercent(log logr.Logger) string {

--- a/controllers/syncer.go
+++ b/controllers/syncer.go
@@ -323,13 +323,25 @@ func (r *ResourceSyncer) syncServiceLevels(ctx context.Context) error {
 }
 
 func (r *ResourceSyncer) syncSLORules(ctx context.Context) error {
-	if err := r.applyPlan(ctx, "Delete App SLO Rules", &rmplan.DeleteSLORules{
-		App:       r.instance.Spec.App,
-		Namespace: r.instance.TargetNamespace(),
-	}); err != nil {
-		return err
+	slos, labels := r.prepareServiceLevelObjectives()
+	if len(slos) > 0 {
+		if err := r.applyPlan(ctx, "Sync App SLO Rules", &rmplan.SyncSLORules{
+			App:                         r.instance.Spec.App,
+			Namespace:                   r.instance.TargetNamespace(),
+			Labels:                      r.defaultLabels(),
+			ServiceLevelObjectiveLabels: labels,
+			ServiceLevelObjectives:      slos,
+		}); err != nil {
+			return err
+		}
+	} else {
+		if err := r.applyPlan(ctx, "Delete App SLO Rules", &rmplan.DeleteSLORules{
+			App:       r.instance.Spec.App,
+			Namespace: r.instance.TargetNamespace(),
+		}); err != nil {
+			return err
+		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
# Update Picchu to Fix Canary and SLOs

## Why Was This Necessary?
I did not realize until after the fact that Picchu uses pre-generated Prometheus recording rules to create the queries for Canarying evaluation.
This means that canary stage is unreliable right now, or at least is not able to use real metrics to determine health. 
It also means that our SLOs in general are not working properly because some of them are referencing recording rules that do not exist!

## The Fix
Revert my change for the `syncSLORules` method in Picchu to once again apply prometheus rules to the clusters. 
This *should* mean that we once again will have working canary and SLO's, but that presumes no other outstanding fixes need to be made.


Manual testing: 🚫