### PR TITLE
[INF-202] Update picchu CPU requests and memory requests to be more in line with true usage (increase CPU - drop mem slightly)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -33,6 +33,6 @@ spec:
           limits:
             memory: 6Gi
           requests:
-            cpu: "1"
-            memory: 6Gi
+            cpu: "3"
+            memory: 4Gi
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Update Picchu CPU req & Mem

This continues the work to clean up the Infrastructure node group in Delivery.
This incrases CPU requests since Picchu seems to hover around 3CPU rather than the 1 it reqeusts.
Mem usage is below 4G, so lowing that from 6Gi as well


Manual testing: 🚫