### PR TITLE
Set Picchu default release schedule to Humane instead of always permitting release

### DIFF
--- a/controllers/schedule/schedule.go
+++ b/controllers/schedule/schedule.go
@@ -91,6 +91,6 @@ func PermitsRelease(t time.Time, schedule string) bool {
 	case "inhumane", "Inhumane":
 		return inhumanePermitsRelease(t)
 	default:
-		return alwaysPermitsRelease(t)
+		return humanePermitsRelease(t)
 	}
 }


### PR DESCRIPTION
Update Picchu Schedule to Default to Humane Rather than AlwaysPermitsRelease

Until now, Picchu was defaulting to always allow a release if there is no schedule defined in the app.yml under`schedule:`

This will act as a safeguard for when we have change freezes and want to ensure Picchu is not just deploying things that don't have it defined in app.yml 


Manual testing: 🚫