### PR TITLE
fix casing for h2Upgrade Istio settings

### DIFF
--- a/config/crd/bases/picchu.medium.engineering_revisions.yaml
+++ b/config/crd/bases/picchu.medium.engineering_revisions.yaml
@@ -1229,7 +1229,7 @@ spec:
                                 http:
                                   description: HTTP connection pool settings.
                                   properties:
-                                    h2_upgrade_policy:
+                                    h2UpgradePolicy:
                                       description: Specify if http1.1 connection should
                                         be upgraded to http2 for the associated destination.
                                       format: int32
@@ -1786,7 +1786,7 @@ spec:
                                       http:
                                         description: HTTP connection pool settings.
                                         properties:
-                                          h2_upgrade_policy:
+                                          h2UpgradePolicy:
                                             description: Specify if http1.1 connection
                                               should be upgraded to http2 for the
                                               associated destination.

--- a/hack/fix.sh
+++ b/hack/fix.sh
@@ -2,3 +2,4 @@
 
 find ./vendor/istio.io -type f -exec grep 'protobuf_oneof' -l {} \; -exec perl -i -pe's/(protobuf_oneof.*)`$/$1 json:\"-\"`/g' {} \;
 find ./vendor/istio.io -type f -exec grep ',omitempty"`$' -l {} \; -exec perl -i -pe 's/(,proto3" json:")([^,"]+)([^"]*)("?,)/$1 . lcfirst(join("", map { ucfirst($_) } split("_", $2))) . $3 . $4/ge;' {} \;
+find ./vendor/istio.io -type f -exec grep 'h2_upgrade_policy,omitempty' -l {} \; -exec perl -i -pe 's/h2_upgrade_policy,omitempty/h2UpgradePolicy,omitempty/g' {} \;


### PR DESCRIPTION
Manual testing: 🚫
This PR is to fix the h2Upgrade warnings from kbfd, it is expecting camelCase instead of snake_case.
![Screen Shot 2024-02-06 at 10 08 17 AM](https://github.com/Medium/picchu/assets/13385331/d4c8594d-da3a-4679-9026-569d5a63054c)
