### PR TITLE
reduce deploying and created state timeout to 1hr from 2hr

### DIFF
--- a/controllers/state.go
+++ b/controllers/state.go
@@ -51,8 +51,8 @@ const (
 	canaried       State = "canaried"
 	timingout      State = "timingout"
 
-	DeployingTimeout = time.Duration(2) * time.Hour
-	CreatedTimeout   = time.Duration(2) * time.Hour
+	DeployingTimeout = time.Hour
+	CreatedTimeout   = time.Hour
 )
 
 var AllStates []string


### PR DESCRIPTION
Timeout for revisions in deploying and created state was 2hrs and felt a bit long. We have alerting at 40min when a revision is in a stuck state, so set the timeout to 2hours
Manual testing: 🚫