### PR TITLE
remove canary crash loop and image pull back slos

### DIFF
--- a/controllers/plan/syncCanaryRules_test.go
+++ b/controllers/plan/syncCanaryRules_test.go
@@ -147,50 +147,6 @@ var (
 							},
 						},
 					},
-					{
-						Name: "test_app_canary_crashloop",
-						Rules: []monitoringv1.Rule{
-							{
-								Alert: "test_app_canary_crashloop",
-								Expr:  intstr.FromString("sum by (reason) (kube_pod_container_status_waiting_reason{reason=\"CrashLoopBackOff\", container=\"test-app\", pod=~\"tag-.*\"}) > 0"),
-								For:   "1m",
-								Annotations: map[string]string{
-									CanaryMessageAnnotation: "There is at least one pod in state `CrashLoopBackOff`",
-									CanarySummaryAnnotation: "test-app - Canary is failing CrashLoopBackOff SLO - there is at least one pod in state `CrashLoopBackOff`",
-								},
-								Labels: map[string]string{
-									CanaryAppLabel: "test-app",
-									CanaryTagLabel: "tag",
-									CanaryLabel:    "true",
-									CanarySLOLabel: "true",
-									"severity":     "test",
-									"channel":      "#eng-releases",
-								},
-							},
-						},
-					},
-					{
-						Name: "test_app_canary_imagepullbackoff",
-						Rules: []monitoringv1.Rule{
-							{
-								Alert: "test_app_canary_imagepullbackoff",
-								Expr:  intstr.FromString("sum by (reason) (kube_pod_container_status_waiting_reason{reason=\"ImagePullBackOff\", container=\"test-app\", pod=~\"tag-.*\"}) > 0"),
-								For:   "1m",
-								Annotations: map[string]string{
-									CanaryMessageAnnotation: "There is at least one pod in state `ImagePullBackOff`",
-									CanarySummaryAnnotation: "test-app - Canary is failing ImagePullBackOff SLO - there is at least one pod in state `ImagePullBackOff`",
-								},
-								Labels: map[string]string{
-									CanaryAppLabel: "test-app",
-									CanaryTagLabel: "tag",
-									CanaryLabel:    "true",
-									CanarySLOLabel: "true",
-									"severity":     "test",
-									"channel":      "#eng-releases",
-								},
-							},
-						},
-					},
 				},
 			},
 		},


### PR DESCRIPTION
Remove ImagePullBackOff and CrashLoopBackOff SLOs from the canary SLOs that was added in [this PR](https://github.com/Medium/picchu/pull/414)
They are not useful and don't contribute to canary
Manual testing: 🚫