### PR TITLE
update datadog monitor and datadog slo naming conventions - <service-name>-<condensed-target>-<condensed-slo-name>-<tag>

### DIFF
--- a/controllers/plan/syncDatadogSLOs.go
+++ b/controllers/plan/syncDatadogSLOs.go
@@ -87,12 +87,31 @@ func (p *SyncDatadogSLOs) datadogSLOs() (*ddog.DatadogSLOList, error) {
 	return ddogSLOList, nil
 }
 
+// jubilee-prod-sched-ssmps-main-20250226-235320-6c2cfd92bc
+
 func (p *SyncDatadogSLOs) datadogSLOName(sloName string) string {
-	// example: <service-name>-<target>-<slo-name>-<commit hash in tag>
+	// example: <service-name>-<condensed-target>-<condensed-slo-name>-<tag>
 	// lowercase - at most 63 characters - start and end with alphanumeric
-	sloName = strings.ReplaceAll(sloName, "-", "")
-	end_tag := strings.LastIndex(p.Tag, "-")
-	front_tag := p.App + "-" + p.Target + "-" + sloName + "-" + p.Tag[end_tag+1:]
+
+	target := ""
+	if strings.Contains(p.Target, "-") {
+		t := strings.LastIndex(p.Target, "-")
+		first_target := p.Target[:4]
+		second_target := p.Target[t+1 : t+5]
+		target = first_target + "-" + second_target
+	} else {
+		target = p.Target[:4]
+	}
+
+	slo_name_end := strings.LastIndex(sloName, "-")
+	new_slo_name := string(sloName[0])
+	for i := range slo_name_end + 1 {
+		if string(sloName[i]) == "-" {
+			new_slo_name = new_slo_name + string(sloName[i+1])
+		}
+	}
+
+	front_tag := p.App + "-" + target + "-" + new_slo_name + "-" + p.Tag
 	if len(front_tag) > 63 {
 		front_tag = front_tag[:63]
 	}

--- a/controllers/plan/syncDatadogSLOs_test.go
+++ b/controllers/plan/syncDatadogSLOs_test.go
@@ -33,7 +33,7 @@ var (
 		},
 		DatadogSLOs: []*picchuv1alpha1.DatadogSLO{
 			{
-				Name:        "slo1",
+				Name:        "istio-request-success",
 				Description: "test create example datadogSLO one",
 				Query: picchuv1alpha1.DatadogSLOQuery{
 					GoodEvents:  "per_minute(sum:istio.mesh.request.count.total{(response_code:2* OR response_code:3* OR response_code:4*) AND destination_service:tutu.tutu-production.svc.cluster.local AND reporter:destination}.as_count())",
@@ -49,7 +49,7 @@ var (
 				Type:            "metric",
 			},
 			{
-				Name:        "slo2",
+				Name:        "http-availability",
 				Description: "test create example datadogSLO two",
 				Query: picchuv1alpha1.DatadogSLOQuery{
 					GoodEvents:  "per_minute(sum:istio.mesh.request.count.total{(response_code:2* OR response_code:3* OR response_code:4*) AND destination_service:echo.echo-production.svc.cluster.local AND reporter:destination}.as_count())",
@@ -74,7 +74,7 @@ var (
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					// 	return fmt.Sprintf("%s-%s-%s-%s-datadogSLO", p.App, p.Target, p.Tag, sloName)
-					Name:      "echo-prod-slo1-456",
+					Name:      "echo-prod-irs-main-123-456",
 					Namespace: "datadog",
 					Labels: map[string]string{
 						picchuv1alpha1.LabelApp:        "echo",
@@ -84,7 +84,7 @@ var (
 					},
 				},
 				Spec: ddog.DatadogSLOSpec{
-					Name:        "echo-prod-main-123-456-slo1",
+					Name:        "echo-prod-main-123-456-istio-request-success",
 					Description: &descrption_one,
 					Query: &ddog.DatadogSLOQuery{
 						Numerator:   "per_minute(sum:istio.mesh.request.count.total{destination_version:main-123-456 AND (response_code:2* OR response_code:3* OR response_code:4*) AND destination_service:tutu.tutu-production.svc.cluster.local AND reporter:destination}.as_count())",
@@ -103,7 +103,7 @@ var (
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					// 	return fmt.Sprintf("%s-%s-%s-%s-datadogSLO", p.App, p.Target, p.Tag, sloName)
-					Name:      "echo-prod-slo2-456",
+					Name:      "echo-prod-ha-main-123-456",
 					Namespace: "datadog",
 					Labels: map[string]string{
 						picchuv1alpha1.LabelApp:        "echo",
@@ -113,7 +113,7 @@ var (
 					},
 				},
 				Spec: ddog.DatadogSLOSpec{
-					Name:        "echo-prod-main-123-456-slo2",
+					Name:        "echo-prod-main-123-456-http-availability",
 					Description: &descrption_two,
 					Query: &ddog.DatadogSLOQuery{
 						Numerator:   "per_minute(sum:istio.mesh.request.count.total{destination_version:main-123-456 AND (response_code:2* OR response_code:3* OR response_code:4*) AND destination_service:echo.echo-production.svc.cluster.local AND reporter:destination}.as_count())",
@@ -167,7 +167,7 @@ var (
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					// 	return fmt.Sprintf("%s-%s-%s-%s-datadogSLO", p.App, p.Target, p.Tag, sloName)
-					Name:      "example-prod-exampleslo-456-eb",
+					Name:      "production-newsletterv3preview-production-newsletterv3previewsqsmessagesprocessedsuccess-456-eb",
 					Namespace: "datadog",
 					Labels: map[string]string{
 						picchuv1alpha1.LabelApp:        "echo",
@@ -212,8 +212,8 @@ func TestDatadogSLOs(t *testing.T) {
 	defer ctrl.Finish()
 
 	tests := []client.ObjectKey{
-		{Name: "echo-prod-slo1-456", Namespace: "datadog"},
-		{Name: "echo-prod-slo2-456", Namespace: "datadog"},
+		{Name: "echo-prod-irs-main-123-456", Namespace: "datadog"},
+		{Name: "echo-prod-ha-main-123-456", Namespace: "datadog"},
 	}
 
 	// tests_monitor := []client.ObjectKey{

--- a/controllers/plan/syncDatadogSLOs_test.go
+++ b/controllers/plan/syncDatadogSLOs_test.go
@@ -167,18 +167,36 @@ var (
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					// 	return fmt.Sprintf("%s-%s-%s-%s-datadogSLO", p.App, p.Target, p.Tag, sloName)
-					Name:      "example-prod-example-slo-datadomonitor",
+					Name:      "example-prod-exampleslo-456-eb",
 					Namespace: "datadog",
 					Labels: map[string]string{
-						picchuv1alpha1.LabelApp:        "FART",
+						picchuv1alpha1.LabelApp:        "echo",
 						picchuv1alpha1.LabelTag:        "main-123-456",
 						picchuv1alpha1.LabelK8sName:    "echo",
 						picchuv1alpha1.LabelK8sVersion: "main-123-456",
 					},
 				},
 				Spec: ddog.DatadogMonitorSpec{
-					Name:  "example-slo",
+					Name:  "example-prod-main-123-456-example-slo-error-budget",
 					Query: "error_budget(\"" + "echo-slo1" + "\").over(\"7d\") > 10",
+					Type:  ddog.DatadogMonitorTypeSLO,
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					// 	return fmt.Sprintf("%s-%s-%s-%s-datadogSLO", p.App, p.Target, p.Tag, sloName)
+					Name:      "example-prod-exampleslo-456-br",
+					Namespace: "datadog",
+					Labels: map[string]string{
+						picchuv1alpha1.LabelApp:        "echo",
+						picchuv1alpha1.LabelTag:        "main-123-456",
+						picchuv1alpha1.LabelK8sName:    "echo",
+						picchuv1alpha1.LabelK8sVersion: "main-123-456",
+					},
+				},
+				Spec: ddog.DatadogMonitorSpec{
+					Name:  "example-prod-main-123-456-example-slo-burn-rate",
+					Query: "burn_rate(\"" + "echo-slo1" + "\").over(\"7d\") > 10",
 					Type:  ddog.DatadogMonitorTypeSLO,
 				},
 			},
@@ -199,7 +217,8 @@ func TestDatadogSLOs(t *testing.T) {
 	}
 
 	// tests_monitor := []client.ObjectKey{
-	// 	{Name: "example-prod-example-slo-datadogmonitor", Namespace: "datadog"},
+	// 	{Name: "example-prod-exampleslo-456-br", Namespace: "datadog"},
+	// 	{Name: "example-prod-exampleslo-456-eb", Namespace: "datadog"},
 	// }
 
 	ctx := context.TODO()


### PR DESCRIPTION
This PR updates the datadogMonitor kubernetes objects to follow the naming convention `<service-name>-<condensed-target>-<condensed-slo-name>-<tag>-<monitorr-type>` ex. `jubilee-prod-sched-ssmps-main-20250226-235320-6c2cfd92bc-burn-rate`
It also updated the datadogSLO kubernetes objects to follow the naming convention `<service-name>-<condensed-target>-<condensed-slo-name>-<tag>` ex. `jubilee-prod-sched-ssmps-main-20250226-235320-6c2cfd92bc`

These objects exists in the datadog namespace in the delivery cluster

It updates the datadogMonitor to follow this naming convention <service-name>-<target>-<tag>-<slo-name>-<burn-rate OR error-budget>. This is what the name of the SLO will be in the datadog UI

Manual testing: 🚫