### PR TITLE
update syncer_test to update datadog states, update incarnation.go so that canarydatadog and canaryingdatadog are incorporated into canary timestamps and metrics

### DIFF
--- a/controllers/garbagecollector/defaultStrategy_test.go
+++ b/controllers/garbagecollector/defaultStrategy_test.go
@@ -50,6 +50,8 @@ func TestDefaultStrategyVariousStates(t *testing.T) {
 		rev(1, 2014, "tested"),
 		rev(1, 2015, "canarying"),
 		rev(1, 2004, "retired"),
+		rev(1, 2016, "canarieddatadog"),
+		rev(1, 2017, "canaryingdatadog"),
 	}
 	testLogger := logr.Logger{}
 	out, err := FindGarbage(testLogger, DefaultStrategy, in)
@@ -77,6 +79,8 @@ func TestDefaultStrategyNonExpiredRevisions(t *testing.T) {
 		rev(1, 2014, "tested"),
 		rev(1, 2015, "canarying"),
 		rev(1, 2004, "retired"),
+		rev(1, 2016, "canarieddatadog"),
+		rev(1, 2017, "canaryingdatadog"),
 		// undeletable because of ttl
 		rev(1, time.Now().Year()+1, "retired"),
 		rev(1, time.Now().Year()+2, "retired"),
@@ -109,6 +113,8 @@ func TestDefaultStrategyNotEnoughExpired(t *testing.T) {
 		rev(1, 2013, "canaried"),
 		rev(1, 2014, "tested"),
 		rev(1, 2015, "canarying"),
+		rev(1, 2016, "canarieddatadog"),
+		rev(1, 2017, "canaryingdatadog"),
 	}
 	testLogger := logr.Logger{}
 	out, err := FindGarbage(testLogger, DefaultStrategy, in)


### PR DESCRIPTION

Manual testing: 🚫