### PR TITLE
update IsCanaryPending - if no SLOs are defined and datadogMonitoring is not enabled, do not canary

### DIFF
--- a/api/v1alpha1/revision_types.go
+++ b/api/v1alpha1/revision_types.go
@@ -305,7 +305,7 @@ func (r *RevisionTarget) IsExternalTestSuccessful() bool {
 
 func (r *RevisionTarget) IsCanaryPending(startTime *metav1.Time) bool {
 	// if canary values aren't set or no SLOs set up for service
-	if r.Canary.Percent == 0 || r.Canary.TTL == 0 || len(r.SlothServiceLevelObjectives) == 0 {
+	if r.Canary.Percent == 0 || r.Canary.TTL == 0 || (len(r.SlothServiceLevelObjectives) == 0 && !r.DatadogMonitoring.Enabled) {
 		return false
 	}
 


### PR DESCRIPTION
If no SLOs are defined and datadogMonitoring is not enabled, do not canary. When datadogMonitoring is enabled, the list of SLOs will be 0 but we still want to canary. This change updates IsCanaryPending to return false if the list of SLOs is 0 AND datadogMonitoring is disabled.
Manual testing: 🚫