### PR TITLE
update events api IsRevisionTriggered so we query for the canary monitors that belong to specific targets

### DIFF
--- a/controllers/revision_controller.go
+++ b/controllers/revision_controller.go
@@ -213,7 +213,7 @@ func (r *RevisionReconciler) Reconcile(ctx context.Context, request reconcile.Re
 
 	// this block ois only for echo - it will execute IsRevisionTriggered but does nothing else
 	var canary_monitor_triggered bool
-	if instance.Spec.App.Name == "echo" {
+	if instance.Spec.App.Name == "echo" || instance.Spec.App.Name == "fred" {
 		prod_canarying := false
 		prod_target := "production"
 		for _, t := range status.Targets {

--- a/datadog/events_api.go
+++ b/datadog/events_api.go
@@ -96,9 +96,11 @@ func (a DDOGEVENTSAPI) queryWithCache(ctx context.Context, query string) (datado
 }
 
 // IsRevisionTriggered returns the true if any datadog metric canary monitoras are triggereing
-func (a DDOGEVENTSAPI) IsRevisionTriggered(ctx context.Context, app string, tag string) (bool, error) {
+func (a DDOGEVENTSAPI) IsRevisionTriggered(ctx context.Context, app string, tag string, target string) (bool, error) {
 	// Query: datadog.PtrString("*-<service>-canary-monitor AND status:error AND version:<tag>")
-	canary_monitor_query := "*-" + app + "-canary-monitor AND status:error AND version:" + tag
+
+	// tags:echo-production
+	canary_monitor_query := "*-" + app + "-canary-monitor AND status:error AND version:" + tag + " AND tags:" + target
 	val, err := a.queryWithCache(ctx, canary_monitor_query)
 	if err != nil {
 		events_log.Error(err, "Error when calling `queryWithCach`\n", "error", err, "response", val)


### PR DESCRIPTION

Manual testing: 🚫