### PR TITLE
open up datadog canary monitoring revert functionality to all services, do not query for production targets in events api, remove some logging

### DIFF
--- a/controllers/incarnation.go
+++ b/controllers/incarnation.go
@@ -18,7 +18,6 @@ import (
 	es "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 	istiov1alpha3 "istio.io/api/networking/v1alpha3"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -305,9 +304,6 @@ func (i *Incarnation) isCanaryPending() bool {
 	if target == nil {
 		return false
 	}
-	if i.appName() == "echo" {
-		log.Info("isCanaryPending() incarnation - Checking if Datadog canary is pending", "target", target.Name, "canary start timestamp", i.status.CanaryStartTimestamp, "iscanarypending", target.IsCanaryPending(i.status.CanaryStartTimestamp))
-	}
 	return target.IsCanaryPending(i.status.CanaryStartTimestamp)
 }
 
@@ -315,9 +311,6 @@ func (i *Incarnation) datadogMonitoring() bool {
 	target := i.target()
 	if target == nil {
 		return false
-	}
-	if i.appName() == "echo" {
-		log.Info("datadogMonitoring() - Checking if Datadog monitoring is enabled for incarnation", "target", target.Name, "ddog monitoring", target.DatadogMonitoring.Enabled)
 	}
 	return target.DatadogMonitoring.Enabled
 }

--- a/controllers/revision_controller.go
+++ b/controllers/revision_controller.go
@@ -92,12 +92,12 @@ func (n *NoopPromAPI) IsRevisionTriggered(ctx context.Context, name, tag string,
 }
 
 type DatadogEventsAPI interface {
-	IsRevisionTriggered(ctx context.Context, app string, tag string, target string) (bool, error)
+	IsRevisionTriggered(ctx context.Context, app string, tag string) (bool, error)
 }
 
 type NoopDatadogEventsAPI struct{}
 
-func (n *NoopDatadogEventsAPI) IsRevisionTriggered(ctx context.Context, app string, tag string, target string) (bool, error) {
+func (n *NoopDatadogEventsAPI) IsRevisionTriggered(ctx context.Context, app string, tag string) (bool, error) {
 	return false, nil
 }
 
@@ -211,28 +211,24 @@ func (r *RevisionReconciler) Reconcile(ctx context.Context, request reconcile.Re
 		}
 	}
 
-	// this block ois only for echo - it will execute IsRevisionTriggered but does nothing else
 	var canary_monitor_triggered bool
-	if instance.Spec.App.Name == "echo" || instance.Spec.App.Name == "fred" {
-		prod_canarying := false
-		prod_target := "production"
-		for _, t := range status.Targets {
-			// if we are in thist state, ddogmonitoring is enabled
-			if strings.Contains(t.Name, "production") && t.State == "canaryingdatadog" {
-				// prod target is canarying
-				prod_canarying = true
-				prod_target = t.Name
-				log.Info("Production target is canarying with datadog monitors", "Target", prod_target)
-			}
-		}
 
-		// check if canary monitor are triggered
-		if prod_canarying {
-			canary_monitor_triggered, err = r.DatadogEventsAPI.IsRevisionTriggered(context.TODO(), instance.Spec.App.Name, instance.Spec.App.Tag, prod_target)
-			if err != nil {
-				log.Error(err, "Datadog events api IsRevisionTriggered error", "Error", err)
-				return r.Requeue(log, err)
-			}
+	prod_datadogcanarying := false
+	for _, t := range status.Targets {
+		// if we are in thist state, ddogmonitoring is enabled
+		if strings.Contains(t.Name, "production") && t.State == "canaryingdatadog" {
+			// one or more prod targets are canarying
+			prod_datadogcanarying = true
+			log.Info("Production target is canarying with datadog monitors", "Target", t.Name)
+		}
+	}
+
+	// check if canary monitor are triggered
+	if prod_datadogcanarying {
+		canary_monitor_triggered, err = r.DatadogEventsAPI.IsRevisionTriggered(context.TODO(), instance.Spec.App.Name, instance.Spec.App.Tag)
+		if err != nil {
+			log.Error(err, "Datadog events api IsRevisionTriggered error", "Error", err)
+			return r.Requeue(log, err)
 		}
 	}
 

--- a/datadog/events_api.go
+++ b/datadog/events_api.go
@@ -96,11 +96,11 @@ func (a DDOGEVENTSAPI) queryWithCache(ctx context.Context, query string) (datado
 }
 
 // IsRevisionTriggered returns the true if any datadog metric canary monitoras are triggereing
-func (a DDOGEVENTSAPI) IsRevisionTriggered(ctx context.Context, app string, tag string, target string) (bool, error) {
+func (a DDOGEVENTSAPI) IsRevisionTriggered(ctx context.Context, app string, tag string) (bool, error) {
 	// Query: datadog.PtrString("*-<service>-canary-monitor AND status:error AND version:<tag>")
 
 	// tags:echo-production
-	canary_monitor_query := "*-" + app + "-canary-monitor AND status:error AND version:" + tag + " AND tags:" + target
+	canary_monitor_query := "*-" + app + "-canary-monitor AND status:error AND version:" + tag
 	val, err := a.queryWithCache(ctx, canary_monitor_query)
 	if err != nil {
 		events_log.Error(err, "Error when calling `queryWithCach`\n", "error", err, "response", val)


### PR DESCRIPTION

Manual testing: 🚫