### PR TITLE
[COR-923] Register missing metrics with controller-runtime registry

### DIFF
--- a/controllers/revision_controller.go
+++ b/controllers/revision_controller.go
@@ -50,6 +50,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -76,6 +77,10 @@ var (
 // +kubebuilder:rbac:groups=picchu.medium.engineering,resources=revisions/status,verbs=get;update;patch
 
 func (r *RevisionReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	metrics.Registry.MustRegister(
+		revisionFailedGauge,
+		mirrorFailureCounter,
+	)
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{MaxConcurrentReconciles: r.Config.ConcurrentRevisions}).
 		For(&picchuv1alpha1.Revision{}).


### PR DESCRIPTION
## Summary

- `revisionFailedGauge` (`picchu_revision_failed`) and `mirrorFailureCounter` (`picchu_mirror_failure_counter`) were only registered via `promauto` (global Prometheus registry) but not with the controller-runtime `metrics.Registry`
- Since controller-runtime serves `/metrics` from its own registry, these two metrics were absent from the endpoint
- Added `metrics.Registry.MustRegister()` call in `RevisionReconciler.SetupWithManager()` to match the pattern already used in `ReleaseManagerReconciler.SetupWithManager()`

## Test plan

- [ ] Verify build passes (`go build ./...`)
- [ ] Verify `go vet` passes
- [ ] After deploy, confirm `picchu_revision_failed` and `picchu_mirror_failure_counter` appear at `:8383/metrics`
- [ ] Confirm no panic from double-registration (promauto uses default registry, MustRegister uses controller-runtime registry — they are separate)

Companion PR in mono: will link after creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)