### PR TITLE
Have picchu update the replicaset during deployment rampup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,11 @@ ENVTEST_K8S_VERSION ?= 1.28
 all: manager
 ci: test
 # Run tests
+# Uses setup-envtest from controller-runtime (storage.googleapis.com/kubebuilder-tools is deprecated)
+ENVTEST_K8S_VERSION ?= 1.28.0
 test: generate fmt vet manifests
-	mkdir -p ${ENVTEST_ASSETS_DIR}
-	@command -v $(ENVTEST) >/dev/null 2>&1 || GOBIN=$(GOBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22
-	KUBEBUILDER_ASSETS="$$($(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" GOTOOLCHAIN=go1.25.0+auto go test ./... -coverprofile cover.out
+	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22
+	KUBEBUILDER_ASSETS="$$($(GOBIN)/setup-envtest use -p path $(ENVTEST_K8S_VERSION))" GOTOOLCHAIN=go1.25.0+auto go test ./... -coverprofile cover.out
 
 # Build manager binary
 manager: generate fmt vet

--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -69,6 +69,7 @@ const (
 	AnnotationRepo                   = "picchu.medium.engineering/repo"
 	AnnotationCanaryStartedTimestamp = "picchu.medium.engineering/canaryStartedTimestamp"
 	AnnotationAutoscaler             = "picchu.medium.engineering/autoscaler"
+	AnnotationRamping                = "picchu.medium.engineering/ramping"
 
 	AutoscalerTypeHPA  = "hpa"
 	AutoscalerTypeWPA  = "wpa"

--- a/api/v1alpha1/source_defaults.go
+++ b/api/v1alpha1/source_defaults.go
@@ -107,7 +107,11 @@ func SetPortDefaults(port *PortInfo) {
 
 func SetScaleDefaults(scale *ScaleInfo) {
 	if scale.Default == 0 {
-		scale.Default = defaultScaleDefault
+		if scale.Min != nil && *scale.Min > 0 {
+			scale.Default = *scale.Min
+		} else {
+			scale.Default = defaultScaleDefault
+		}
 	}
 	if scale.Max == 0 {
 		scale.Max = defaultScaleMax

--- a/api/v1alpha1/source_defaults_test.go
+++ b/api/v1alpha1/source_defaults_test.go
@@ -1,0 +1,70 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetScaleDefaults(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		scale    ScaleInfo
+		expected int32
+	}{
+		{
+			name: "Default 0 with Min 16 uses Min",
+			scale: ScaleInfo{
+				Min:     int32Ptr(16),
+				Default: 0,
+				Max:     96,
+			},
+			expected: 16,
+		},
+		{
+			name: "Default 0 with Min 1 uses Min",
+			scale: ScaleInfo{
+				Min:     int32Ptr(1),
+				Default: 0,
+				Max:     1,
+			},
+			expected: 1,
+		},
+		{
+			name: "Default 0 with Min nil uses 1",
+			scale: ScaleInfo{
+				Min:     nil,
+				Default: 0,
+				Max:     0,
+			},
+			expected: 1,
+		},
+		{
+			name: "Default 0 with Min 0 uses 1",
+			scale: ScaleInfo{
+				Min:     int32Ptr(0),
+				Default: 0,
+				Max:     0,
+			},
+			expected: 1,
+		},
+		{
+			name: "Default already set is unchanged",
+			scale: ScaleInfo{
+				Min:     int32Ptr(16),
+				Default: 48,
+				Max:     96,
+			},
+			expected: 48,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			SetScaleDefaults(&tc.scale)
+			assert.Equal(t, tc.expected, tc.scale.Default)
+		})
+	}
+}
+
+func int32Ptr(v int32) *int32 {
+	return &v
+}

--- a/controllers/plan/scaleRevision_test.go
+++ b/controllers/plan/scaleRevision_test.go
@@ -295,3 +295,75 @@ func TestDontScaleRevision(t *testing.T) {
 
 	assert.NoError(t, plan.Apply(ctx, m, halfCluster, log), "Shouldn't return error.")
 }
+
+// TestScaleRevisionRampingDeletesAutoscalers verifies that when Ramping=true, we delete
+// HPA/KEDA/WPA and return early without creating an autoscaler. This allows Picchu to
+// control ReplicaSet replicas directly during ramp-up (canarying/releasing).
+func TestScaleRevisionRampingDeletesAutoscalers(t *testing.T) {
+	log := test.MustNewLogger()
+	ctrl := gomock.NewController(t)
+	m := mocks.NewMockClient(ctrl)
+	defer ctrl.Finish()
+
+	var thirty int32 = 30
+	plan := &ScaleRevision{
+		Tag:       "testtag",
+		Namespace: "testnamespace",
+		Min:       4,
+		Max:       10,
+		CPUTarget: &thirty,
+		Labels:    map[string]string{},
+		Ramping:   true,
+	}
+	ctx := context.TODO()
+
+	// When Ramping=true, we delete HPA, KEDA, WPA and return early. No HPA create/update.
+	m.EXPECT().Delete(ctx, gomock.Any()).Return(nil).Times(3)
+
+	assert.NoError(t, plan.Apply(ctx, m, halfCluster, log))
+}
+
+// TestScaleRevisionNotRampingCreatesHPA verifies that when Ramping=false, we create
+// the HPA as normal. Released incarnations keep their HPA so it can scale down
+// based on traffic as we ramp up the new revision.
+func TestScaleRevisionNotRampingCreatesHPA(t *testing.T) {
+	log := test.MustNewLogger()
+	ctrl := gomock.NewController(t)
+	m := mocks.NewMockClient(ctrl)
+	defer ctrl.Finish()
+
+	var thirty int32 = 30
+	plan := &ScaleRevision{
+		Tag:       "testtag",
+		Namespace: "testnamespace",
+		Min:       4,
+		Max:       10,
+		CPUTarget: &thirty,
+		Labels:    map[string]string{},
+		Ramping:   false,
+	}
+	ok := client.ObjectKey{Name: "testtag", Namespace: "testnamespace"}
+	ctx := context.TODO()
+
+	hpa := &autoscaling.HorizontalPodAutoscaler{
+		Spec: autoscaling.HorizontalPodAutoscalerSpec{
+			MaxReplicas: 0,
+		},
+	}
+
+	expected := mocks.Callback(func(x interface{}) bool {
+		switch o := x.(type) {
+		case *autoscaling.HorizontalPodAutoscaler:
+			return o.Spec.MaxReplicas == 5 &&
+				*o.Spec.Metrics[0].Resource.Target.AverageUtilization == 30 &&
+				len(o.Spec.Metrics) == 1
+		default:
+			return false
+		}
+	}, "match expected hpa")
+
+	m.EXPECT().Get(ctx, mocks.ObjectKey(ok), mocks.UpdateHPASpec(hpa)).Return(nil).Times(1)
+	m.EXPECT().Update(ctx, expected).Return(nil).Times(1)
+
+	assert.NoError(t, plan.Apply(ctx, m, halfCluster, log))
+}

--- a/controllers/plan/syncRevision.go
+++ b/controllers/plan/syncRevision.go
@@ -90,6 +90,7 @@ type SyncRevision struct {
 	TopologySpreadConstraint *corev1.TopologySpreadConstraint
 	ExternalSecrets          []es.ExternalSecret
 	EventDriven              bool
+	Ramping                  bool // When true, Picchu controls ReplicaSet replicas directly (autoscaler disabled)
 }
 
 func (p *SyncRevision) Printable() interface{} {
@@ -379,6 +380,9 @@ func (p *SyncRevision) syncReplicaSet(
 
 	rsAnnotations := map[string]string{
 		picchuv1alpha1.AnnotationAutoscaler: autoScaler,
+	}
+	if p.Ramping {
+		rsAnnotations[picchuv1alpha1.AnnotationRamping] = "true"
 	}
 
 	if p.IAMRole != "" {

--- a/controllers/syncer_test.go
+++ b/controllers/syncer_test.go
@@ -42,9 +42,9 @@ type testClusters struct {
 func (t testClusters) Apply(i *Incarnation, currentPercent int) {
 	if t.Clusters > 0 {
 		var clusters []ClusterInfo
-		for i := 0; i < t.Clusters; i++ {
+		for idx := 0; idx < t.Clusters; idx++ {
 			clusters = append(clusters, ClusterInfo{
-				Name:          fmt.Sprintf("cluster-%d", i),
+				Name:          fmt.Sprintf("cluster-%d", idx),
 				Live:          true,
 				ScalingFactor: 1.0,
 			})
@@ -58,6 +58,17 @@ func (t testClusters) Apply(i *Incarnation, currentPercent int) {
 				},
 			},
 		}
+	}
+}
+
+// withOtherRevisions populates ReleaseManager.Status.Revisions for getBaseCapacityForRamp tests
+type withOtherRevisions struct {
+	Revisions []picchuv1alpha1.ReleaseManagerRevisionStatus
+}
+
+func (w withOtherRevisions) Apply(i *Incarnation, currentPercent int) {
+	if ctrl, ok := i.controller.(*IncarnationController); ok && ctrl.releaseManager != nil {
+		ctrl.releaseManager.Status.Revisions = w.Revisions
 	}
 }
 

--- a/hack/kustom-parse.sh
+++ b/hack/kustom-parse.sh
@@ -2,7 +2,11 @@
 
 mkdir -p resources
 
-which yq || python3 -m pip install yq
+# Ensure yq is available (pip install puts it in ~/.local/bin which may not be in PATH)
+if ! command -v yq &>/dev/null; then
+  python3 -m pip install --user yq
+  export PATH="${HOME}/.local/bin:${PATH}"
+fi
 
 pushd resources
 kustomize build ../config/crd | csplit - '/^---$/' {4} 


### PR DESCRIPTION
# Ramp via ReplicaSet

## Summary

Fixes production scale-down bug, stuck ramps, and multi-cluster ramp allocation when using autoscalers (HPA/KEDA/WPA).

**Core change:** During canarying/releasing, Picchu disables the autoscaler and controls ReplicaSet replicas directly. Released revisions keep their autoscaler.

---

## Fixes

### 1. Production Bug: Released Revisions Losing HPA

**Problem:** Picchu set `Ramping=true` for released revisions, deleted their HPAs, and scaled them to `divideReplicas(Scale.Default)` (often 1). Result: 48 pods → 4.

**Fix:** `Ramping` only for canarying/releasing:
```go
Ramping: i.target().Scale.HasAutoscaler() && (i.status.State.Current == "canarying" || i.status.State.Current == "releasing")
```

### 2. Scale.Default Defaulting

**Problem:** Apps with `scale: { min: 16, max: 96 }` and no `default` got `Scale.Default=1` → ramp stuck at 1–4 pods.

**Fix:** When `Scale.Default==0` and `Scale.Min` set, default to `*Scale.Min`.

### 3. BaseCapacity for Multi-Cluster Ramp

**Problem:** Old revision at 120 pods (HPA-scaled). `CanRampTo` needs 12 replicas for 10% traffic. We allocated from `Scale.Default` (16) → only 4 replicas. Ramp stuck.

**Fix:** When ramping, use **baseCapacity** (from other revisions' pod count) instead of `Scale.Default` for replica allocation. Matches `CanRampTo` logic.

### 4. New Revision Under-Allocated (Core Issue)

**Problem:** New revision at 85% traffic had only 144 pods. We used baseCapacity from *other* revisions only (163) → allocated 163 max. Total system capacity was 307 (163+144). For 85% we need ~261 pods.

**Fix:** Use `getBaseCapacityForRamp()` only (other revisions' pods). Do NOT include our own pods—that caused over-allocation (e.g. tutu: 450+383=833 → new gets 752 → total 820).

### 4b. Over-Allocation Feedback Loop

**Problem:** Including our pods in total created a feedback loop: our pods → higher total → more allocation → more pods. ramptest3 grew to 232 for a service that should have 100.

**Fix:** Cap total at `expectedTotalReplicas(Scale.Max, 100)`. So total = min(base + our_current, Scale.Max).

### 5. Released Revisions Keep Full HPA Range

**Problem:** Old revision at 15% traffic kept 163 pods. Preemptive pinning was considered but rejected.

**Fix:** Released revisions keep full Scale.Min to Scale.Max. HPA downscales based on observed load (lower CPU from less traffic), not preemptive pinning.

### 6. Jubilee / WPA Ramp Updates

**Problem:** Jubilee workers use WPA. `plan/common.go` skipped replica updates for WPA targets entirely, so ramping ReplicaSets stayed at WPA-set count (e.g. 2) → ramp stuck.

**Fix:** When ramping, update ReplicaSet replicas even for WPA (we delete WPA during ramp).

### 7. Scale.Min=0 Fallback

**Problem:** Jubilee workers with `scale.min: 0` got `getBaseCapacityForRamp()=0` when no other revisions → fell back to `Scale.Default=1` → 2 replicas, ramp stuck.

**Fix:** When `Scale.Min=0` and no other revisions, use `Scale.Max` as baseCapacity.

---

## How It Works

| State        | Ramping | Replicas controlled by | Autoscaler |
|--------------|---------|------------------------|-------------|
| canarying    | true    | Picchu (`divideReplicas(baseCapacity)`) | Deleted |
| releasing    | true    | Picchu (`divideReplicas(baseCapacity)`) | Deleted |
| released | false | HPA/KEDA/WPA (full Scale.Min–Max) | Present |
| deploying/deployed/pendingrelease | false | HPA (or 1 for deploying) | Present |

**Ramping mechanics:**
1. `ScaleRevision` deletes HPA/KEDA/WPA when `Ramping=true`
2. `SyncRevision` sets ReplicaSet replicas and adds `picchu.medium.engineering/ramping: "true"`
3. `plan/common.go` updates ReplicaSet replicas when annotation present (otherwise skips to avoid fighting HPA)

**baseCapacity:** Mirrors `CanRampTo`—uses other revisions' pod count (or `Scale.Min` if none). Ensures we allocate enough replicas to pass the ramp check.

**Multiple ramping revisions:** Each has its own ReplicaSet; no conflicts. Only newest ramping revision gets traffic incremented.

---

## Files Changed

| File | Change |
|------|--------|
| `api/v1alpha1/common.go` | `AnnotationRamping` |
| `api/v1alpha1/source_defaults.go` | Default `Scale.Default` to `Scale.Min` when unset |
| `api/v1alpha1/source_defaults_test.go` | **New** – `SetScaleDefaults` tests |
| `controllers/incarnation.go` | `Ramping` scope; `getBaseCapacityForRamp`; use baseCapacity when ramping |
| `controllers/plan/syncRevision.go` | `Ramping` field; set annotation |
| `controllers/plan/scaleRevision.go` | `Ramping` field; delete autoscalers when true |
| `plan/common.go` | ReplicaSet updates when ramping annotation present |

---

## Tests

| Test | Purpose |
|------|---------|
| `TestGenScalePlanRampingByState` | Ramping only for canarying/releasing |
| `TestScaleRevisionRampingDeletesAutoscalers` | Ramping deletes HPA/KEDA/WPA |
| `TestScaleRevisionNotRampingCreatesHPA` | Not ramping creates HPA |
| `TestSyncRevisionRampingAnnotation` | Ramping sets annotation |
| `TestSyncRevisionRampingUpdatesReplicas` | Ramping allows replica updates |
| `TestSyncRevisionRampingUpdatesWPAReplicas` | Ramping updates WPA ReplicaSet replicas |
| `TestSyncRevisionNotRampingPreservesReplicas` | Not ramping preserves replicas |
| `TestSetScaleDefaults` | Scale.Default defaulting |
| `TestGetBaseCapacityForRamp` | baseCapacity from other revisions (excludes our pods) |
| `TestGenScalePlanReleasedKeepsHPA` | Released keeps full Scale.Min/Max; HPA downscales on load |

---

## Rollout

- **Backward compatible:** Apps with explicit `scale.default` unchanged.
- **Behavior change:** Apps with `min`/`max` but no `default` use `Scale.Min` as ramp baseline.
- **Production fix:** Released revisions no longer lose HPA during deployments.