### PR TITLE
use reporter for scaling pods

### DIFF
--- a/controllers/plan/scaleRevision.go
+++ b/controllers/plan/scaleRevision.go
@@ -182,7 +182,7 @@ func (p *ScaleRevision) applyHPA(ctx context.Context, cli client.Client, cluster
 
 func (p *ScaleRevision) applyAmbientKeda(ctx context.Context, cli client.Client, log logr.Logger, scaledMin int32, scaledMax int32) error {
 	query := fmt.Sprintf(
-		`sum(rate(istio_requests_total{destination_workload="%s", namespace="%s"}[2m]))`,
+		`sum(rate(istio_requests_total{destination_workload="%s", namespace="%s", reporter=~"(waypoint|destination)"}[2m]))`,
 		p.Tag, p.Namespace,
 	)
 


### PR DESCRIPTION

Manual testing: 🚫

This PR avoids double counting destination/waypoint and source reporter