### PR TITLE
Cap CanRampTo fleet requirement at Scale.Max

### DIFF
--- a/controllers/scaling.go
+++ b/controllers/scaling.go
@@ -75,6 +75,13 @@ func (s *ScalableTargetAdapter) computeFleetReplicasRequiredForRamp(desiredPerce
 
 	totalReplicas := float64(controller.expectedTotalReplicas(baseCapacity, int32(desiredPercent)))
 	expectedReplicas := int32(math.Ceil(totalReplicas * Threshold))
+	// Never require more fleet replicas than Scale.Max can produce (normalized baseCapacity can exceed Max).
+	if target.Scale.Max > 0 {
+		maxFleet := controller.expectedTotalReplicas(target.Scale.Max, 100)
+		if expectedReplicas > maxFleet {
+			expectedReplicas = maxFleet
+		}
+	}
 
 	return &rampReplicaComputation{
 		expectedReplicas:    expectedReplicas,

--- a/controllers/scaling_ramp_test.go
+++ b/controllers/scaling_ramp_test.go
@@ -26,6 +26,29 @@ func (s testTargetRequestsRate) Apply(i *Incarnation, currentPercent int) {
 	i.revision.Spec.Targets[0].Scale.TargetRequestsRate = &s.Rate
 }
 
+func TestComputeFleetReplicasRequiredForRamp_capsExpectedReplicasAtScaleMax(t *ttesting.T) {
+	// Same normalization as TestComputeFleetReplicasRequiredForRamp_normalizedOtherRevisions (baseCapacity 40).
+	// At desiredPercent 100: uncapped ceil(0.9 * expectedTotalReplicas(40,100)) would exceed Scale.Max=20.
+	i := createTestIncarnation(
+		"new",
+		releasing,
+		10,
+		testClusters{Clusters: 4},
+		testReleaseManagerStatus{
+			Revisions: []picchuv1alpha1.ReleaseManagerRevisionStatus{
+				{Tag: "old", CurrentPercent: 90, PeakPercent: 90, Scale: picchuv1alpha1.ReleaseManagerRevisionScaleStatus{Current: 36}},
+			},
+		},
+	)
+	i.revision.Spec.Targets[0].Scale.Max = 20
+
+	sta := ScalableTargetAdapter{Incarnation: *i}
+	c, ok := sta.computeFleetReplicasRequiredForRamp(100)
+	assert.True(t, ok)
+	assert.NotNil(t, c)
+	assert.EqualValues(t, 20, c.expectedReplicas)
+}
+
 func TestComputeFleetReplicasRequiredForRamp_normalizedOtherRevisions(t *ttesting.T) {
 	// 4 live clusters @ 1.0 scaling; other revision at 90% / 36 fleet pods => baseCapacity 40.
 	// PeakPercent < 100 so we use normalized capacity (not the "unscaled from 100%" branch).


### PR DESCRIPTION
## Summary

`computeFleetReplicasRequiredForRamp` could require more fleet-wide replicas than `RevisionTarget.Scale.Max` can ever produce when normalized `baseCapacity` from other revisions exceeds `Max`. That left releases stuck (e.g. `expectedReplicas` above achievable capacity while `currentReplicas` already matched `Max`).

## Change

After computing the 90% threshold replica requirement, clamp `expectedReplicas` to `expectedTotalReplicas(Scale.Max, 100)` when `Scale.Max > 0`, so `CanRampTo` and proactive HPA min never target unreachable capacity.

## Test

- `TestComputeFleetReplicasRequiredForRamp_capsExpectedReplicasAtScaleMax`
- `go test ./controllers/ -run 'TestComputeFleetReplicasRequiredForRamp|TestCanRampTo|TestProactiveRampMinReplicas'`

Made with [Cursor](https://cursor.com)