### PR TITLE
Treat KedaWorker as HasAutoscaler for ramp and RS sizing

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -179,7 +179,8 @@ func (s *ScaleInfo) HasAutoscaler() bool {
 	return s.TargetCPUUtilizationPercentage != nil ||
 		s.TargetRequestsRate != nil ||
 		s.TargetMemoryUtilizationPercentage != nil ||
-		s.Worker != nil
+		s.Worker != nil ||
+		s.KedaWorker != nil
 }
 
 type ReleaseInfo struct {

--- a/api/v1alpha1/revision_test.go
+++ b/api/v1alpha1/revision_test.go
@@ -114,6 +114,7 @@ func TestScaleInfo_HasAutoscaler(t *testing.T) {
 		TargetMemoryUtilizationPercentage *int32
 		TargetRequestsRate                *string
 		Worker                            *WorkerScaleInfo
+		KedaWorker                        *KedaScaleInfo
 		Expected                          bool
 	}{
 		{
@@ -140,6 +141,11 @@ func TestScaleInfo_HasAutoscaler(t *testing.T) {
 			Worker:   &WorkerScaleInfo{},
 			Expected: true,
 		},
+		{
+			Name:       "KedaWorker Defined",
+			KedaWorker: &KedaScaleInfo{},
+			Expected:   true,
+		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
 			assert := assert.New(t)
@@ -148,6 +154,7 @@ func TestScaleInfo_HasAutoscaler(t *testing.T) {
 				TargetMemoryUtilizationPercentage: test.TargetMemoryUtilizationPercentage,
 				TargetRequestsRate:                test.TargetRequestsRate,
 				Worker:                            test.Worker,
+				KedaWorker:                        test.KedaWorker,
 			}
 			assert.Equal(test.Expected, s.HasAutoscaler())
 		})


### PR DESCRIPTION
## Summary

`ScaleInfo.HasAutoscaler()` now returns true when `KedaWorker` is set, matching WPA (`Worker`), CPU, memory, and RPS.

## Why

KEDA-only targets were treated as **non-autoscaled** in ramp math: `computeFleetReplicasRequiredForRamp` used normalized traffic extrapolation instead of the `hasUnscaledRevision` + autoscaler path that uses `totalPods` as `baseCapacity`. That inflated expected replicas vs KEDA-driven counts and could stall ramps.

WPA was already included; KEDA was an omission.

## Behavior

- `hasUnscaledRevision` + autoscaler: `baseCapacity = totalPods` for KEDA as well (aligned with Jubilee/WPA).
- `genSyncRevision` uses `divideReplicas(Default)` for KEDA (traffic-scaled) instead of `divideReplicasNoAutoscale`.
- `proactiveRampMinReplicas` still returns 0 when `KedaWorker != nil` (unchanged early return).

## Test

- Extended `TestScaleInfo_HasAutoscaler` with a KedaWorker case.

Please run `make test` locally before merge.

Made with [Cursor](https://cursor.com)