### PR TITLE
use destination_workload_namespace field

### DIFF
--- a/controllers/plan/scaleRevision.go
+++ b/controllers/plan/scaleRevision.go
@@ -182,7 +182,7 @@ func (p *ScaleRevision) applyHPA(ctx context.Context, cli client.Client, cluster
 
 func (p *ScaleRevision) applyAmbientKeda(ctx context.Context, cli client.Client, log logr.Logger, scaledMin int32, scaledMax int32) error {
 	query := fmt.Sprintf(
-		`sum(rate(istio_requests_total{destination_workload="%s", namespace="%s"}[2m]))`,
+		`sum(rate(istio_requests_total{destination_workload="%s", destination_workload_namespace="%s"}[2m]))`,
 		p.Tag, p.Namespace,
 	)
 


### PR DESCRIPTION

Manual testing: 🚫
Istio sidecar/gateway does not route to waypoint proxies, so metric collection needs to happen at the source.