### PR TITLE
fix(waypoint): stamp Datadog unified service tags on waypoint pods

### DIFF
--- a/controllers/plan/ensureWaypoint.go
+++ b/controllers/plan/ensureWaypoint.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -30,13 +31,22 @@ const (
 	gatewayListenerProto           = "HBONE"
 )
 
-// waypointDeploymentOverlayBase is the Istio parametersRef "deployment" overlay: a toleration for the
-// dedicated waypoint nodepool taint plus required node affinity for waypoint-labeled nodes.
-const waypointDeploymentOverlayBase = `spec:
+// ddUnifiedServiceTagsPlaceholder is replaced in waypointDeploymentOverlayTemplate with the
+// JSON-encoded Datadog unified service tags for the app the waypoint fronts. A placeholder is used
+// (rather than fmt.Sprintf) so the '%%host%%' Datadog autodiscovery variable is left untouched.
+const ddUnifiedServiceTagsPlaceholder = "__DD_UNIFIED_SERVICE_TAGS__"
+
+// waypointDeploymentOverlayTemplate is the Istio parametersRef "deployment" overlay: Datadog pod
+// annotations (the istio-proxy autodiscovery check plus the unified service tags, so waypoint pods
+// are attributable to their app for cost allocation — PLT-3301), a toleration for the dedicated
+// waypoint nodepool taint, and required node affinity for waypoint-labeled nodes.
+// buildWaypointDeploymentOverlay renders ddUnifiedServiceTagsPlaceholder before use.
+const waypointDeploymentOverlayTemplate = `spec:
   template:
     metadata:
       annotations:
         ad.datadoghq.com/istio-proxy.checks: '{"istio":{"init_config":{},"instances":[{"use_openmetrics":true,"istio_mode":"ambient","waypoint_endpoint":"http://%%host%%:15020/stats/prometheus","collect_histogram_buckets":true}]}}'
+        ad.datadoghq.com/tags: '__DD_UNIFIED_SERVICE_TAGS__'
     spec:
       tolerations:
         - key: waypoint
@@ -53,15 +63,23 @@ const waypointDeploymentOverlayBase = `spec:
                       - waypoint
 `
 
-func buildWaypointDeploymentOverlay(resources *corev1.ResourceRequirements) (string, error) {
+// buildWaypointDeploymentOverlay renders the parametersRef "deployment" overlay for a waypoint,
+// stamping the Datadog unified service tags (service=app, env) so the waypoint pods are attributed
+// to their app. The waypoint fronts every revision in the namespace, so no version tag is set.
+func buildWaypointDeploymentOverlay(app, env string, resources *corev1.ResourceRequirements) (string, error) {
+	tags, err := json.Marshal(map[string]string{"env": env, "service": app})
+	if err != nil {
+		return "", err
+	}
+	base := strings.Replace(waypointDeploymentOverlayTemplate, ddUnifiedServiceTagsPlaceholder, string(tags), 1)
 	if resources == nil || waypointResourcesEmpty(*resources) {
-		return waypointDeploymentOverlayBase, nil
+		return base, nil
 	}
 	resourcesYAML, err := buildWaypointResourcesOverlay(*resources)
 	if err != nil {
 		return "", err
 	}
-	return waypointDeploymentOverlayBase + resourcesYAML, nil
+	return base + resourcesYAML, nil
 }
 
 func waypointResourcesEmpty(r corev1.ResourceRequirements) bool {
@@ -118,11 +136,13 @@ var gatewayGVK = schema.GroupVersionKind{
 // spec.infrastructure.parametersRef. It contains the "deployment" overlay for waypoint scheduling.
 type EnsureWaypointOptions struct {
 	Namespace string
+	App       string
+	Env       string
 	Resources *corev1.ResourceRequirements
 }
 
 func (p *EnsureWaypointOptions) Apply(ctx context.Context, cli client.Client, cluster *picchuv1alpha1.Cluster, log logr.Logger) error {
-	overlay, err := buildWaypointDeploymentOverlay(p.Resources)
+	overlay, err := buildWaypointDeploymentOverlay(p.App, p.Env, p.Resources)
 	if err != nil {
 		return err
 	}

--- a/controllers/plan/ensureWaypoint_test.go
+++ b/controllers/plan/ensureWaypoint_test.go
@@ -2,24 +2,30 @@ package plan
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	testify "github.com/stretchr/testify/assert"
 	ktest "go.medium.engineering/kubernetes/pkg/test"
 	"go.medium.engineering/picchu/test"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 
 	_ "go.medium.engineering/kubernetes/pkg/test/core/v1"
 )
 
 func TestBuildWaypointDeploymentOverlayWithoutResources(t *testing.T) {
 	assert := testify.New(t)
-	overlay, err := buildWaypointDeploymentOverlay(nil)
+	overlay, err := buildWaypointDeploymentOverlay("my-app", "production", nil)
 	assert.NoError(err)
-	assert.Equal(waypointDeploymentOverlayBase, overlay)
+	// Unified service tags are stamped for the app the waypoint fronts (PLT-3301).
+	assert.Contains(overlay, `ad.datadoghq.com/tags: '{"env":"production","service":"my-app"}'`)
+	assert.NotContains(overlay, ddUnifiedServiceTagsPlaceholder)
+	// The istio-proxy autodiscovery check and its %%host%% variable must survive rendering.
+	assert.Contains(overlay, "ad.datadoghq.com/istio-proxy.checks")
+	assert.Contains(overlay, "%%host%%")
 }
 
 func TestBuildWaypointDeploymentOverlayWithResources(t *testing.T) {
@@ -34,9 +40,9 @@ func TestBuildWaypointDeploymentOverlayWithResources(t *testing.T) {
 			corev1.ResourceMemory: resource.MustParse("256Mi"),
 		},
 	}
-	overlay, err := buildWaypointDeploymentOverlay(resources)
+	overlay, err := buildWaypointDeploymentOverlay("my-app", "production", resources)
 	assert.NoError(err)
-	assert.True(strings.HasPrefix(overlay, waypointDeploymentOverlayBase))
+	assert.Contains(overlay, `ad.datadoghq.com/tags: '{"env":"production","service":"my-app"}'`)
 	assert.Contains(overlay, "containers:")
 	assert.Contains(overlay, "name: istio-proxy")
 	assert.Contains(overlay, "requests:")
@@ -45,6 +51,24 @@ func TestBuildWaypointDeploymentOverlayWithResources(t *testing.T) {
 	assert.Contains(overlay, "limits:")
 	assert.Contains(overlay, "cpu: 1")
 	assert.Contains(overlay, "memory: 256Mi")
+}
+
+// TestBuildWaypointDeploymentOverlayIsValidYAML round-trips the rendered overlay through the
+// Deployment type (PICCHU-INV-MESH-5) and asserts the unified service tags land on the pod template.
+func TestBuildWaypointDeploymentOverlayIsValidYAML(t *testing.T) {
+	assert := testify.New(t)
+	resources := &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("250m")},
+	}
+	overlay, err := buildWaypointDeploymentOverlay("my-app", "production", resources)
+	assert.NoError(err)
+
+	var deployment appsv1.Deployment
+	assert.NoError(yaml.Unmarshal([]byte(overlay), &deployment))
+	assert.Equal(`{"env":"production","service":"my-app"}`, deployment.Spec.Template.Annotations["ad.datadoghq.com/tags"])
+	assert.Contains(deployment.Spec.Template.Annotations, "ad.datadoghq.com/istio-proxy.checks")
+	assert.Len(deployment.Spec.Template.Spec.Containers, 1)
+	assert.Equal("istio-proxy", deployment.Spec.Template.Spec.Containers[0].Name)
 }
 
 func TestEnsureWaypointOptionsWithResources(t *testing.T) {
@@ -59,11 +83,13 @@ func TestEnsureWaypointOptionsWithResources(t *testing.T) {
 			corev1.ResourceCPU: resource.MustParse("250m"),
 		},
 	}
-	overlay, err := buildWaypointDeploymentOverlay(resources)
+	overlay, err := buildWaypointDeploymentOverlay("my-app", "production", resources)
 	assert.NoError(err)
 
 	en := &EnsureWaypointOptions{
 		Namespace: "namespace",
+		App:       "my-app",
+		Env:       "production",
 		Resources: resources,
 	}
 	assert.NoError(en.Apply(ctx, cli, cluster, log))

--- a/controllers/syncer.go
+++ b/controllers/syncer.go
@@ -185,6 +185,8 @@ func (r *ResourceSyncer) syncNamespace(ctx context.Context) error {
 	if needWaypoint {
 		if err := r.applyPlan(ctx, "Ensure Waypoint Options", &rmplan.EnsureWaypointOptions{
 			Namespace: ns,
+			App:       r.instance.Spec.App,
+			Env:       r.instance.Spec.Target,
 			Resources: r.effectiveWaypointResources(),
 		}); err != nil {
 			return err

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,10 @@ require (
 	sigs.k8s.io/controller-runtime v0.23.3
 )
 
-require github.com/kedacore/keda/v2 v2.20.1
+require (
+	github.com/kedacore/keda/v2 v2.20.1
+	sigs.k8s.io/yaml v1.6.0
+)
 
 require (
 	github.com/DataDog/zstd v1.5.7 // indirect
@@ -102,7 +105,6 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
 replace (


### PR DESCRIPTION
## Problem (PLT-3301)

Ambient-mesh **waypoint** pods carry no Datadog `service`/`env` unified service tags, so Datadog **cost allocation cannot attribute them** to the app they front. In `ml-rank-production` the waypoints are the majority of pods by count (small CPU, but real node cost on the dedicated `waypoint-ondemand` nodepool).

Root cause: kbfd stamps the `ad.datadoghq.com/tags` annotation only on the **app** pod template. The waypoint Deployment is rendered by istiod from the `waypoint-options` `parametersRef` ConfigMap and never received it — grouping `kubernetes.cpu.usage.total{kube_namespace:ml-rank-production}` by `service` returns exactly two groups: `service:ml-rank` (app pods) and `service:N/A` (`kube_deployment:waypoint`, `istio-proxy`).

## Change

Render the unified service tags into the waypoint deployment overlay so istiod propagates them onto the waypoint pods:

- Add `ad.datadoghq.com/tags` (`{"env":<target>,"service":<app>}`) to the overlay's `spec.template.metadata.annotations`, alongside the existing `istio-proxy.checks` annotation.
- A placeholder + `strings.Replace` (not `fmt.Sprintf`) is used so the `%%host%%` Datadog autodiscovery variable in the checks annotation is left untouched.
- Thread `App`/`Env` from the `ReleaseManager` spec (`Spec.App`, `Spec.Target`) into `EnsureWaypointOptions`. `env=target` matches the value kbfd stamps on the app pods (verified: app pods are `env:production`).
- The waypoint fronts **every** revision in the namespace, so no `version` tag is set.

This fixes **all** ambient-mesh apps, not just ml-rank.

## Invariants

- **PICCHU-INV-MESH-8** — customization goes through the `waypoint-options` overlay ConfigMap, never the Gateway/Deployment object. ✅
- **PICCHU-INV-MESH-5** (aspirational) — adds a YAML round-trip test that unmarshals the rendered overlay into a `Deployment` and asserts the tags land on the pod template.

## Testing

- `go build ./controllers/...`, `go vet ./controllers/...` — clean.
- `go test ./controllers/plan/...` — pass (incl. new `TestBuildWaypointDeploymentOverlayIsValidYAML`).
- `controllers` envtest suite (`TestAPIs`) needs `KUBEBUILDER_ASSETS` (not installed locally); unaffected by this change — fails identically on clean `main`.

## Rollout note

Existing waypoints pick up the tags on the next reconcile (the `waypoint-options` ConfigMap `data.deployment` changes → istiod re-renders the waypoint Deployment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)