### PR TITLE
remove do not disrupt annotation after created/deploying phase

### DIFF
--- a/controllers/incarnation.go
+++ b/controllers/incarnation.go
@@ -343,6 +343,18 @@ func (i *Incarnation) isTimingOut() bool {
 	return lastUpdated.Add(timeout).Before(time.Now())
 }
 
+// karpenterDoNotDisrupt returns the configured karpenter.sh/do-not-disrupt
+// value while the incarnation is still deploying, and clears it once the
+// deploying state is complete so Karpenter can disrupt the node again.
+func (i *Incarnation) karpenterDoNotDisrupt() string {
+	switch State(i.status.State.Current) {
+	case created, deploying:
+		return i.target().KarpenterDoNotDisrupt
+	default:
+		return ""
+	}
+}
+
 // Remotely sync the incarnation for it's current state
 func (i *Incarnation) sync(ctx context.Context) error {
 	// Revision deleted
@@ -394,7 +406,7 @@ func (i *Incarnation) sync(ctx context.Context) error {
 		Resources:                i.target().Resources,
 		IAMRole:                  i.target().AWS.IAM.RoleARN,
 		PodAnnotations:           i.target().PodAnnotations,
-		KarpenterDoNotDisrupt:    i.target().KarpenterDoNotDisrupt,
+		KarpenterDoNotDisrupt:    i.karpenterDoNotDisrupt(),
 		ServiceAccountName:       i.target().ServiceAccountName,
 		ReadinessProbe:           i.target().ReadinessProbe,
 		LivenessProbe:            i.target().LivenessProbe,

--- a/controllers/incarnation_test.go
+++ b/controllers/incarnation_test.go
@@ -279,6 +279,27 @@ func TestIncarnation_divideReplicasNoAutoscale(t *ttesting.T) {
 	}
 }
 
+func TestIncarnation_karpenterDoNotDisrupt(t *ttesting.T) {
+	const configured = "30m"
+
+	for _, test := range []struct {
+		Name  string
+		State State
+		Want  string
+	}{
+		{Name: "created", State: created, Want: configured},
+		{Name: "deploying", State: deploying, Want: configured},
+		{Name: "deployed", State: deployed, Want: ""},
+		{Name: "releasing", State: releasing, Want: ""},
+	} {
+		t.Run(test.Name, func(t *ttesting.T) {
+			i := createTestIncarnation("test", test.State, 0)
+			i.revision.Spec.Targets[0].KarpenterDoNotDisrupt = configured
+			assert.Equal(t, test.Want, i.karpenterDoNotDisrupt())
+		})
+	}
+}
+
 func Test_IsExpired(t *ttesting.T) {
 	for _, test := range []struct {
 		Name              string

--- a/controllers/plan/syncRevision_test.go
+++ b/controllers/plan/syncRevision_test.go
@@ -558,6 +558,30 @@ func TestSyncRevisionKarpenterDoNotDisruptOverridesPodAnnotation(t *testing.T) {
 	assert.Equal(t, 1, len(rsl.Items))
 	common.ResourcesEqual(t, expected, &rsl.Items[0])
 }
+
+func TestSyncRevisionKarpenterDoNotDisruptRemovedAfterDeploy(t *testing.T) {
+	log := test.MustNewLogger()
+	ctx := context.TODO()
+
+	plan := *defaultRevisionPlan
+	plan.KarpenterDoNotDisrupt = "30m"
+
+	cli := fakeClient(defaultExpectedReplicaSet, defaultServiceAccount)
+	assert.NoError(t, plan.Apply(ctx, cli, halfCluster, log))
+
+	rsl := &appsv1.ReplicaSetList{}
+	assert.NoError(t, cli.List(ctx, rsl))
+	assert.Equal(t, "30m", rsl.Items[0].Spec.Template.Annotations[picchuv1alpha1.AnnotationKarpenterDoNotDisrupt])
+
+	plan.KarpenterDoNotDisrupt = ""
+	assert.NoError(t, plan.Apply(ctx, cli, halfCluster, log))
+
+	assert.NoError(t, cli.List(ctx, rsl))
+	_, ok := rsl.Items[0].Spec.Template.Annotations[picchuv1alpha1.AnnotationKarpenterDoNotDisrupt]
+	assert.False(t, ok)
+	assert.Equal(t, defaultExpectedReplicaSet.Spec.Template.Spec.Containers[0].Image, rsl.Items[0].Spec.Template.Spec.Containers[0].Image)
+}
+
 func TestSyncRevisionSchedulerName(t *testing.T) {
 	log := test.MustNewLogger()
 	ctx := context.TODO()

--- a/plan/common.go
+++ b/plan/common.go
@@ -404,6 +404,15 @@ func CreateOrUpdate(
 
 			if len(rs.Spec.Template.Labels) == 0 {
 				rs.Spec.Template = typed.Spec.Template
+			} else if rs.Spec.Template.Annotations != nil {
+				// The pod template is otherwise frozen after creation, but this
+				// annotation must be removable once an incarnation is done deploying,
+				// so it's kept in sync independent of the rest of the template.
+				if v, ok := typed.Spec.Template.Annotations[picchu.AnnotationKarpenterDoNotDisrupt]; ok && v != "" {
+					rs.Spec.Template.Annotations[picchu.AnnotationKarpenterDoNotDisrupt] = v
+				} else {
+					delete(rs.Spec.Template.Annotations, picchu.AnnotationKarpenterDoNotDisrupt)
+				}
 			}
 			rs.Spec.Selector = typed.Spec.Selector
 			rs.Labels = typed.Labels

--- a/plan/common_test.go
+++ b/plan/common_test.go
@@ -6,12 +6,14 @@ import (
 	"time"
 
 	es "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	"github.com/stretchr/testify/assert"
 	test2 "go.medium.engineering/kubernetes/pkg/test"
 	coreAsserts "go.medium.engineering/kubernetes/pkg/test/core/v1"
 	externalSecretAsserts "go.medium.engineering/kubernetes/pkg/test/external-secrets/externalsecrets/v1"
 	picchu "go.medium.engineering/picchu/api/v1alpha1"
 	picchuScheme "go.medium.engineering/picchu/client/scheme"
 	"go.medium.engineering/picchu/test"
+	appsv1 "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -24,6 +26,7 @@ var (
 
 func init() {
 	core.AddToScheme(picchuScheme.Scheme)
+	appsv1.AddToScheme(picchuScheme.Scheme)
 	es.AddToScheme(picchuScheme.Scheme)
 	coreAsserts.RegisterAsserts(comparator)
 	externalSecretAsserts.RegisterAsserts(comparator)
@@ -300,6 +303,102 @@ func TestIgnore(t *testing.T) {
 			cli := fake.NewClientBuilder().WithScheme(picchuScheme.Scheme).WithObjects(test.Existing).Build()
 			CreateOrUpdate(ctx, log, cli, test.Updated)
 			comparator.AssertMatch(ctx, t, cli, test.Expected)
+		})
+	}
+}
+
+func TestCreateOrUpdateReplicaSetKarpenterDoNotDisrupt(t *testing.T) {
+	log := test.MustNewLogger()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(10)*time.Second)
+	defer cancel()
+
+	const (
+		namespace = "testnamespace"
+		name      = "testtag"
+	)
+
+	podLabels := map[string]string{
+		"app":                           "testapp",
+		"tag.picchu.medium.engineering": name,
+	}
+	podAnnotations := func(karpenterValue string) map[string]string {
+		annotations := map[string]string{
+			"other-annotation": "keep-me",
+		}
+		if karpenterValue != "" {
+			annotations[picchu.AnnotationKarpenterDoNotDisrupt] = karpenterValue
+		}
+		return annotations
+	}
+	replicas := int32(1)
+	replicaSet := func(image string, karpenterValue string) *appsv1.ReplicaSet {
+		return &appsv1.ReplicaSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: appsv1.ReplicaSetSpec{
+				Replicas: &replicas,
+				Selector: metav1.SetAsLabelSelector(podLabels),
+				Template: core.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels:      podLabels,
+						Annotations: podAnnotations(karpenterValue),
+					},
+					Spec: core.PodSpec{
+						Containers: []core.Container{{
+							Name:  "app",
+							Image: image,
+						}},
+					},
+				},
+			},
+		}
+	}
+
+	for _, test := range []struct {
+		Name             string
+		Existing         *appsv1.ReplicaSet
+		Updated          *appsv1.ReplicaSet
+		ExpectedKarpenter string
+		ExpectedImage    string
+	}{
+		{
+			Name:              "removes annotation after deploying",
+			Existing:          replicaSet("old-image:tag", "30m"),
+			Updated:           replicaSet("new-image:tag", ""),
+			ExpectedKarpenter: "",
+			ExpectedImage:     "old-image:tag",
+		},
+		{
+			Name:              "adds annotation while deploying",
+			Existing:          replicaSet("old-image:tag", ""),
+			Updated:           replicaSet("new-image:tag", "30m"),
+			ExpectedKarpenter: "30m",
+			ExpectedImage:     "old-image:tag",
+		},
+		{
+			Name:              "updates annotation while deploying",
+			Existing:          replicaSet("old-image:tag", "30m"),
+			Updated:           replicaSet("new-image:tag", "true"),
+			ExpectedKarpenter: "true",
+			ExpectedImage:     "old-image:tag",
+		},
+	} {
+		t.Run(test.Name, func(t *testing.T) {
+			cli := fake.NewClientBuilder().WithScheme(picchuScheme.Scheme).WithObjects(test.Existing).Build()
+			assert.NoError(t, CreateOrUpdate(ctx, log, cli, test.Updated))
+
+			got := &appsv1.ReplicaSet{}
+			assert.NoError(t, cli.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, got))
+			assert.Equal(t, test.ExpectedImage, got.Spec.Template.Spec.Containers[0].Image)
+			assert.Equal(t, "keep-me", got.Spec.Template.Annotations["other-annotation"])
+			if test.ExpectedKarpenter == "" {
+				_, ok := got.Spec.Template.Annotations[picchu.AnnotationKarpenterDoNotDisrupt]
+				assert.False(t, ok)
+			} else {
+				assert.Equal(t, test.ExpectedKarpenter, got.Spec.Template.Annotations[picchu.AnnotationKarpenterDoNotDisrupt])
+			}
 		})
 	}
 }


### PR DESCRIPTION

Manual testing: 🚫
This PR removes the karpenter DoNotDisrupt annotation after a revision has completed the created/deploying phase. 