### PR TITLE
check stage branch tag names so that they are not longer than 54 characters - when keda-hpa- prefix is added we do not go over the 63 char limit

### DIFF
--- a/controllers/plan/scaleRevision.go
+++ b/controllers/plan/scaleRevision.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 
 	picchuv1alpha1 "go.medium.engineering/picchu/api/v1alpha1"
 
@@ -86,7 +87,7 @@ func (p *ScaleRevision) Apply(ctx context.Context, cli client.Client, cluster *p
 		// admission webhook rejection ("workload is already managed by the hpa").
 		hpa := &autoscaling.HorizontalPodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      p.Tag,
+				Name:      p.hpaName(),
 				Namespace: p.Namespace,
 			},
 		}
@@ -97,6 +98,15 @@ func (p *ScaleRevision) Apply(ctx context.Context, cli client.Client, cluster *p
 	}
 
 	return p.applyHPA(ctx, cli, cluster, log, scaledMin, scaledMax)
+}
+
+// if tag name is greater than 54 it will not accomodate the prefix that will be added "keda-hpa-"
+// trim the front of the tag to allow for the prefix and so that we dont go over the 63char limit
+func (p *ScaleRevision) hpaName() string {
+	if len(p.Tag) <= 54 {
+		return p.Tag
+	}
+	return strings.TrimLeft(p.Tag[len(p.Tag)-54:], "-")
 }
 
 func (p *ScaleRevision) applyHPA(ctx context.Context, cli client.Client, cluster *picchuv1alpha1.Cluster, log logr.Logger, scaledMin int32, scaledMax int32) error {
@@ -149,7 +159,7 @@ func (p *ScaleRevision) applyHPA(ctx context.Context, cli client.Client, cluster
 	if len(metrics) <= 0 {
 		hpa := &autoscaling.HorizontalPodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      p.Tag,
+				Name:      p.hpaName(),
 				Namespace: p.Namespace,
 			},
 		}
@@ -161,7 +171,7 @@ func (p *ScaleRevision) applyHPA(ctx context.Context, cli client.Client, cluster
 
 	hpa := &autoscaling.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      p.Tag,
+			Name:      p.hpaName(),
 			Namespace: p.Namespace,
 			Labels:    p.Labels,
 		},
@@ -188,7 +198,7 @@ func (p *ScaleRevision) applyAmbientKeda(ctx context.Context, cli client.Client,
 
 	keda := &kedav1.ScaledObject{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      p.Tag,
+			Name:      p.hpaName(),
 			Namespace: p.Namespace,
 			Labels:    p.Labels,
 		},
@@ -262,7 +272,7 @@ func (p *ScaleRevision) applyKeda(ctx context.Context, cli client.Client, cluste
 	}
 	keda := &kedav1.ScaledObject{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      p.Tag,
+			Name:      p.hpaName(),
 			Namespace: p.Namespace,
 			Labels:    p.Labels,
 		},

--- a/controllers/plan/scaleRevision_test.go
+++ b/controllers/plan/scaleRevision_test.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	picchuv1alpha1 "go.medium.engineering/picchu/api/v1alpha1"
@@ -358,4 +359,152 @@ func TestDontScaleRevision(t *testing.T) {
 		Times(1)
 
 	assert.NoError(t, plan.Apply(ctx, m, halfCluster, log), "Shouldn't return error.")
+}
+
+// TestScaleRevisionHPANameTruncatedOverLimit verifies that when Tag is longer than the
+// HPA name limit, applyHPA truncates the HPA's own name (keeping the trailing portion,
+// since that's what carries the date-time-commit info that needs to stay unique) while
+// Spec.ScaleTargetRef.Name keeps the full, untruncated Tag so it still matches the real
+// ReplicaSet name (created elsewhere with the untruncated Tag).
+func TestScaleRevisionHPANameTruncatedOverLimit(t *testing.T) {
+	log := test.MustNewLogger()
+	ctrl := gomock.NewController(t)
+	m := mocks.NewMockClient(ctrl)
+	defer ctrl.Finish()
+
+	longTag := "auto-109151-add-design-system-typescript-support-20260903-075707-40a3c27da1"
+	assert.Greater(t, len(longTag), 54, "sanity check: fixture tag should be over the HPA name limit")
+
+	expectedHPAName := longTag[len(longTag)-54:]
+
+	var thirty int32 = 30
+	plan := &ScaleRevision{
+		Tag:       longTag,
+		Namespace: "testnamespace",
+		Min:       4,
+		Max:       10,
+		CPUTarget: &thirty,
+		Labels:    map[string]string{},
+	}
+	ok := client.ObjectKey{Name: expectedHPAName, Namespace: "testnamespace"}
+	ctx := context.TODO()
+
+	hpa := &autoscaling.HorizontalPodAutoscaler{
+		Spec: autoscaling.HorizontalPodAutoscalerSpec{
+			MaxReplicas: 0,
+		},
+	}
+
+	expected := mocks.Callback(func(x interface{}) bool {
+		switch o := x.(type) {
+		case *autoscaling.HorizontalPodAutoscaler:
+			return o.ObjectMeta.Name == expectedHPAName &&
+				o.Spec.ScaleTargetRef.Name == longTag &&
+				o.Spec.MaxReplicas == 5 &&
+				*o.Spec.Metrics[0].Resource.Target.AverageUtilization == 30
+		default:
+			return false
+		}
+	}, "match truncated hpa name with untruncated ScaleTargetRef")
+
+	m.
+		EXPECT().
+		Get(ctx, mocks.ObjectKey(ok), mocks.UpdateHPASpec(hpa)).
+		Return(nil).
+		Times(1)
+
+	m.
+		EXPECT().
+		Update(ctx, expected).
+		Return(nil).
+		Times(1)
+
+	assert.NoError(t, plan.Apply(ctx, m, halfCluster, log), "Shouldn't return error.")
+}
+
+// TestScaleRevisionWithKEDANameTruncatedOverLimit verifies that applyKeda truncates the
+// ScaledObject's own name (via hpaName) when Tag is over the limit, since KEDA's operator
+// prepends "keda-hpa-" to it when generating the underlying HPA. ScaleTargetRef.Name must
+// stay the full, untruncated Tag to match the real ReplicaSet name.
+func TestScaleRevisionWithKEDANameTruncatedOverLimit(t *testing.T) {
+	log := test.MustNewLogger()
+	ctrl := gomock.NewController(t)
+	m := mocks.NewMockClient(ctrl)
+	defer ctrl.Finish()
+
+	longTag := "auto-109151-add-design-system-typescript-support-20260903-075707-40a3c27da1"
+	assert.Greater(t, len(longTag), 54, "sanity check: fixture tag should be over the HPA name limit")
+
+	expectedScaledObjectName := longTag[len(longTag)-54:]
+
+	plan := &ScaleRevision{
+		Tag:        longTag,
+		Namespace:  "testnamespace",
+		Min:        4,
+		Max:        10,
+		KedaWorker: &picchuv1alpha1.KedaScaleInfo{},
+		Labels:     map[string]string{},
+	}
+	// TriggerAuthentication keeps the full, untruncated Tag as its name (it's
+	// not the object KEDA prepends "keda-hpa-" to), while the ScaledObject's
+	// own name is truncated via hpaName - so each Get uses a different key.
+	triggerAuthKey := client.ObjectKey{Name: longTag, Namespace: "testnamespace"}
+	scaledObjectKey := client.ObjectKey{Name: expectedScaledObjectName, Namespace: "testnamespace"}
+	ctx := context.TODO()
+
+	var kedaMaxReplicas int32 = 0
+	keda := &kedav1.ScaledObject{
+		Spec: kedav1.ScaledObjectSpec{
+			MaxReplicaCount: &kedaMaxReplicas,
+		},
+	}
+
+	expected := mocks.Callback(func(x interface{}) bool {
+		switch o := x.(type) {
+		case *kedav1.ScaledObject:
+			return o.ObjectMeta.Name == expectedScaledObjectName &&
+				o.Spec.ScaleTargetRef.Name == longTag &&
+				*o.Spec.MaxReplicaCount == 5
+		case *kedav1.TriggerAuthentication:
+			return true
+		default:
+			return false
+		}
+	}, "match truncated ScaledObject name with untruncated ScaleTargetRef")
+
+	m.
+		EXPECT().
+		Get(ctx, mocks.ObjectKey(triggerAuthKey), mocks.UpdateKEDASpec(keda)).
+		Return(nil).
+		Times(1)
+
+	m.
+		EXPECT().
+		Get(ctx, mocks.ObjectKey(scaledObjectKey), mocks.UpdateKEDASpec(keda)).
+		Return(nil).
+		Times(1)
+
+	m.
+		EXPECT().
+		Update(ctx, expected).
+		Return(nil).
+		Times(2)
+
+	assert.NoError(t, plan.Apply(ctx, m, halfCluster, log), "Shouldn't return error.")
+}
+
+// TestHpaNameTrimsLeadingDash verifies hpaName trims a leading "-" left behind when the
+// 54-char cut happens to land right at a separator, since a k8s object name can't start
+// with "-".
+func TestHpaNameTrimsLeadingDash(t *testing.T) {
+	// Constructed so the last 54 characters begin exactly on a "-": a 10-char prefix,
+	// then "-", then 53 more characters (10 + 1 + 53 = 64 total, so len-54 == 10, which
+	// is exactly where the "-" sits).
+	tag := "auto123456" + "-" + strings.Repeat("y", 53)
+	plan := &ScaleRevision{Tag: tag}
+
+	name := plan.hpaName()
+
+	assert.False(t, strings.HasPrefix(name, "-"), "hpaName should never start with a separator")
+	assert.Equal(t, strings.Repeat("y", 53), name)
 }


### PR DESCRIPTION
This PR updates the naming conventions for HPA objects generated by the ScaledObject in picchu. Automated stage branches are usually long, and if they are longer than 54 chars they will not accommodate the keda-hpa- prefix that is added to the front of the string. We want to cut down the stage branch tag to 54 chars or less so when the prefix is added we dont go over the kubernetes 63 char limit- #644

Manual testing: 🚫